### PR TITLE
Add server pre-commit hook instructions

### DIFF
--- a/docs/getting-started/server/guide.mdx
+++ b/docs/getting-started/server/guide.mdx
@@ -35,12 +35,18 @@ Before you start: make sure you’ve installed the recommended
 
 2.  Open a terminal and navigate to the root of the cloned repository.
 
-## Configure Git blame
+## Configure Git
 
-Configure Git to ignore the Prettier revision:
+1. Configure Git to ignore the Prettier revision:
 
 ```bash
 git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
+2. Set up the pre-commit `dotnet format` hook:
+
+```bash
+git config --local core.hooksPath .git-hooks
 ```
 
 ## Configure Docker

--- a/docs/getting-started/server/guide.mdx
+++ b/docs/getting-started/server/guide.mdx
@@ -39,15 +39,18 @@ Before you start: make sure you’ve installed the recommended
 
 1. Configure Git to ignore the Prettier revision:
 
-```bash
-git config blame.ignoreRevsFile .git-blame-ignore-revs
-```
+   ```bash
+   git config blame.ignoreRevsFile .git-blame-ignore-revs
+   ```
 
-2. Set up the pre-commit `dotnet format` hook:
+2. _(Optional)_ Set up the pre-commit `dotnet format` hook:
 
-```bash
-git config --local core.hooksPath .git-hooks
-```
+   ```bash
+   git config --local core.hooksPath .git-hooks
+   ```
+
+Formatting requires a full build, which may be too slow to do every commit. As an alternative, you
+can run `dotnet format` from the command line when convenient (e.g. before requesting a PR review).
 
 ## Configure Docker
 

--- a/docs/getting-started/server/guide.mdx
+++ b/docs/getting-started/server/guide.mdx
@@ -49,8 +49,8 @@ Before you start: make sure you’ve installed the recommended
    git config --local core.hooksPath .git-hooks
    ```
 
-Formatting requires a full build, which may be too slow to do every commit. As an alternative, you
-can run `dotnet format` from the command line when convenient (e.g. before requesting a PR review).
+   Formatting requires a full build, which may be too slow to do every commit. As an alternative, you
+   can run `dotnet format` from the command line when convenient (e.g. before requesting a PR review).
 
 ## Configure Docker
 

--- a/docs/getting-started/server/guide.mdx
+++ b/docs/getting-started/server/guide.mdx
@@ -49,8 +49,9 @@ Before you start: make sure you’ve installed the recommended
    git config --local core.hooksPath .git-hooks
    ```
 
-   Formatting requires a full build, which may be too slow to do every commit. As an alternative, you
-   can run `dotnet format` from the command line when convenient (e.g. before requesting a PR review).
+   Formatting requires a full build, which may be too slow to do every commit. As an alternative,
+   you can run `dotnet format` from the command line when convenient (e.g. before requesting a PR
+   review).
 
 ## Configure Docker
 


### PR DESCRIPTION
## Objective

Add instructions on how to set up the `dotnet format` pre-commit hook for server. It's in our [README.md](https://github.com/bitwarden/server#dotnet-format) but not in these docs.