### PR TITLE
Fix info callout in MAS dev page

### DIFF
--- a/docs/getting-started/clients/desktop/mac/index.md
+++ b/docs/getting-started/clients/desktop/mac/index.md
@@ -74,9 +74,12 @@ security add-generic-password -a "<apple_id>" -w "<app_specific_password>" -s "A
 
 3. Run `npm run dist:mac:masdev`.
 
-!!! info
+:::info
 
-    If this is your first time running desktop locally, be sure to run `npm ci` before `npm run dist:mac:masdev`.
+If this is your first time running desktop locally, be sure to run `npm ci` before
+`npm run dist:mac:masdev`.
+
+:::
 
 ### Troubleshoot
 


### PR DESCRIPTION
## Objective

I noticed an info callout on the MAS desktop doc is using the old format causing weirdness. Switch to the correct syntax. 
