### PR TITLE
Added troubleshooting to sign already committed changes

### DIFF
--- a/docs/contributing/commit-signing.mdx
+++ b/docs/contributing/commit-signing.mdx
@@ -101,6 +101,19 @@ Refer to
   your terminal. Refer to
   [this troubleshooting document](https://gist.github.com/paolocarrasco/18ca8fe6e63490ae1be23e84a7039374)
   for more help with this error
+- If you have already committed your changes and forgot to configure gpg signing you can fix it by
+  doing a rebase like the following targeting the hash of the previous commit to the one you did (it
+  will sign all commits from there):
+
+  ```bash
+  git rebase --exec 'git commit --amend --no-edit -n -S' -i <previous-commmit-hash>
+  ```
+
+  Beware that if you had already pushed your changes to origin, you are going to have to do a force
+  push in git after applying the fix which shouldn't be harmful on side branches but one needs to
+  pay attention just in case. It's advisable to create a temporary branch before doing this to have
+  a backup in case something goes wrong. If something does go wrong, the simplest solution is to
+  close the PR and create a new one squashing the old PR's commits with signing enabled.
 
 [github-verification]:
   https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification

--- a/docs/contributing/commit-signing.mdx
+++ b/docs/contributing/commit-signing.mdx
@@ -102,11 +102,11 @@ Refer to
   [this troubleshooting document](https://gist.github.com/paolocarrasco/18ca8fe6e63490ae1be23e84a7039374)
   for more help with this error
 - If you have already committed your changes and forgot to configure gpg signing you can fix it by
-  doing a rebase like the following targeting the hash of the previous commit to the one you did (it
-  will sign all commits from there):
+  doing a rebase like the following targeting the hash of current master branch (it will sign all
+  commits on your branch and put them on top of current master's commit):
 
   ```bash
-  git rebase --exec 'git commit --amend --no-edit -n -S' -i <previous-commmit-hash>
+  git rebase --exec 'git commit --amend --no-edit -n -S' -i <current-master-commmit-hash>
   ```
 
   Beware that if you had already pushed your changes to origin, you are going to have to do a force
@@ -114,6 +114,9 @@ Refer to
   pay attention just in case. It's advisable to create a temporary branch before doing this to have
   a backup in case something goes wrong. If something does go wrong, the simplest solution is to
   close the PR and create a new one squashing the old PR's commits with signing enabled.
+
+- On SourceTree, "Commit merged changes immediately" doesn't sign the merged commit so uncheck that
+  option when merging and then commit manually so the flag gets applied.
 
 [github-verification]:
   https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification


### PR DESCRIPTION
## Objective

<!--Describe what the purpose of this PR is.-->
Added fix for the situation in which you have already committed your changes and you forgot to configure GPG signing

_Note: It's a new PR from #44 with all the commits signed given that rebasing there somehow didn't work as I expected (yes it's kind of a paradox given the goal of the PR), maybe for having merges in between or because of targeting a commit in the middle of the PR instead of previous to the beginning of the first PR commit 🤔_ 

_Sorry for calling review again, also added a note to do what I just did with this to fix it without rebasing which is basically create a new PR_