### PR TITLE
Moved title above JSON declaration so that it would display.

### DIFF
--- a/docs/getting-started/server/database/ef/index.mdx
+++ b/docs/getting-started/server/database/ef/index.mdx
@@ -1,6 +1,8 @@
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
+# Entity Framework
+
 export const providers = [
   {
     label: "PostgreSQL",
@@ -15,8 +17,6 @@ export const providers = [
     value: "sqlite",
   },
 ];
-
-# Entity Framework
 
 :::warning
 


### PR DESCRIPTION
## Objective

Moved the `#Entity Framework` title above the `export` declaration so it would display on the menu.

**Before**
![image](https://user-images.githubusercontent.com/106564991/212554059-c720c2c7-63ae-4f11-9b3b-e0e768b2ebe9.png)

**After**
![image](https://user-images.githubusercontent.com/106564991/212554095-e7e9b5ef-a6b3-4a5f-8a44-e86d48b925dd.png)


