### PR TITLE
[PS-2311] Added notes about Visual Studio 2022 requirement for Windows developers.

### DIFF
--- a/docs/getting-started/server/guide.mdx
+++ b/docs/getting-started/server/guide.mdx
@@ -18,12 +18,10 @@ Before you start: make sure you’ve installed the recommended
 [Tools and Libraries](../tools/index.md), including:
 
 - Docker Desktop
-- Visual Studio **
+- Visual Studio 2022
 - Powershell
 - [NET 6.0 SDK](https://dotnet.microsoft.com/download)
 - Azure Data Studio
-
-** If developing in a Windows environment, Visual Studio 2022 is required in order to compile with NET 6.0 SDK framework.  See [this article](https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/vs-msbuild-version) for more details.
 
 :::
 

--- a/docs/getting-started/server/guide.mdx
+++ b/docs/getting-started/server/guide.mdx
@@ -18,10 +18,12 @@ Before you start: make sure you’ve installed the recommended
 [Tools and Libraries](../tools/index.md), including:
 
 - Docker Desktop
-- Visual Studio
+- Visual Studio **
 - Powershell
 - [NET 6.0 SDK](https://dotnet.microsoft.com/download)
 - Azure Data Studio
+
+** If developing in a Windows environment, Visual Studio 2022 is required in order to compile with NET 6.0 SDK framework.  See [this article](https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/vs-msbuild-version) for more details.
 
 :::
 


### PR DESCRIPTION
BW Server project would not compile using Visual Studio 2019 due to NET 6.0 SDK restrictions. Suggested by Thomas Rittsen @eliykat via gitter.im BW Lobby.

## Objective

<!--Describe what the purpose of this PR is.-->
Contributor documentation edits for BitWarden Server Setup guide.