### PR TITLE
Remove commit signing requirements

### DIFF
--- a/docs/contributing/commit-signing.mdx
+++ b/docs/contributing/commit-signing.mdx
@@ -16,8 +16,8 @@ For example, on 3 August 2022, Stephen Lacy
 massive malware attack on GitHub by noticing unverified commits (i.e. commits that were not
 digitally signed).
 
-To protect against commit spoofing, all Bitwarden contributors must digitally sign their commits.
-This is optional but encouraged for community contributors.
+To protect against commit spoofing, all Bitwarden contributors are encouraged to digitally sign
+their commits.
 
 ## Setting up commit signing
 

--- a/docs/getting-started/tools/index.md
+++ b/docs/getting-started/tools/index.md
@@ -39,8 +39,7 @@ environment.
 - [NPM](https://www.npmjs.com/) v8 (included with Node)
 - [Rust](https://www.rust-lang.org/tools/install) - Used for native desktop components
 - [Git](https://git-scm.com)
-  - [Commit signing](../../contributing/commit-signing.mdx) is required for all _Bitwarden
-    contributors_ and is strongly encouraged for _community contributors_.
+  - [Commit signing](../../contributing/commit-signing.mdx) is strongly recommended
 
 ### Mobile
 


### PR DESCRIPTION
## Objective

<!--Describe what the purpose of this PR is.-->

We are no longer requiring commit signing, so we should remove these requirements from our documentation.

I thought about leaving them there for informational purposes, but it's not serving much use and it's just more documentation to maintain.