### PR TITLE
[PM-1321] fix: make it apparent you need dotnet sdk

### DIFF
--- a/docs/getting-started/server/guide.md
+++ b/docs/getting-started/server/guide.md
@@ -17,7 +17,7 @@ Before you start: make sure you’ve installed the recommended
 - Docker Desktop
 - Visual Studio 2022
 - Powershell
-- [NET 6.0 SDK](https://dotnet.microsoft.com/download)
+- **[NET 6.0 SDK](https://dotnet.microsoft.com/download)**
 - Azure Data Studio
 
 :::


### PR DESCRIPTION
If you do `brew install dotnet` you will run into issues with `dotnet restore` command.

To resolve this, you have to install version 6.x from <https://github.com/isen-ng/homebrew-dotnet-sdk-versions#dotnet-sdk-versions-tap>.

We recommend to add this into the docs.  For now, we've simply bolded it.