### PR TITLE
ban regions in code style

### DIFF
--- a/docs/contributing/code-style/index.md
+++ b/docs/contributing/code-style/index.md
@@ -13,3 +13,8 @@ read this section thoroughly as it contains many good advices for avoiding commo
 
 - Include trailing commas for multi-line lists when supported by the language. Inline lists do not
   have to follow this standard.
+
+### Code Regions
+
+- We do not use code regions in the codebase. If you find yourself needing to use a code region,
+  consider refactoring the code to be more readable.


### PR DESCRIPTION
## Objective

<!--Describe what the purpose of this PR is.-->
We have decided to ban the use of code regions within our codebase. This rule mostly applies to C#'s `#regions`, but there are also less standardized regions in TS/JS that we should avoid using as well.