### PR TITLE
Fix broken link typo

### DIFF
--- a/docs/getting-started/server/guide.md
+++ b/docs/getting-started/server/guide.md
@@ -151,7 +151,7 @@ You can connect to it using Azure Data Studio using the following credentials:
 The server uses emails for many user interactions. We provide a pre-configured instance of
 [MailCatcher](https://mailcatcher.me/), which catches any outbound email and prevents it from being
 sent to real email addresses. You can open its web interface at
-[http://localhost:1080.](http://localhost:1080.)
+[http://localhost:1080](http://localhost:1080).
 
 ### Azurite
 


### PR DESCRIPTION
## Objective

Moving an errant `.` out of the link:
![Screenshot 2023-04-26 at 9 19 15 AM](https://user-images.githubusercontent.com/1556494/234599576-3dc29c0b-2a97-4530-bdd3-5c1eb220eace.png)

