### PR TITLE
Update Safari Preferences to Settings

### DIFF
--- a/docs/getting-started/clients/browser/biometric.mdx
+++ b/docs/getting-started/clients/browser/biometric.mdx
@@ -50,10 +50,10 @@ extension development ID to this manifest instead.
 
 - In the local Browser project, run `npm ci`.
 - To use the local browser extension on Safari, use this command: `npm run dist:safari:dmg`. Once
-  this has built, you should see the Bitwarden Extension in Safari's Preferences under the Extension
-  menu. If not, open and build the related Xcode project (usually found in
-  `$HOME/browser/dist/Safari/dmg/desktop.xcodeproj`). It should then show up in the Preferences
-  menu, and you can enable it.
+  this has built, you should see the Bitwarden Extension in Safari's Settings under Extensions menu.
+  If not, open and build the related Xcode project (usually found in
+  `$HOME/browser/dist/Safari/dmg/desktop.xcodeproj`). It should then show up in the Settings
+  Extensions menu, and you can enable it.
 - For other browsers, use `npm run build:watch` and then load the locally built extension using the
   method described [here](./index.md#testing-and-debugging).
 

--- a/docs/getting-started/clients/browser/index.md
+++ b/docs/getting-started/clients/browser/index.md
@@ -168,10 +168,10 @@ from source.
 To avoid this, follow the instructions below to uninstall the Safari extension:
 
 1.  Open Safari
-2.  Click “Preferences” and then click the “Extensions” tab
+2.  Click “Settings” and then click the “Extensions” tab
 3.  Click uninstall next to the Bitwarden extension
 4.  Delete the Application with the extension.
-5.  Reopen Safari and check Preferences to confirm that there is no Bitwarden Browser extension
+5.  Reopen Safari and check Settings to confirm that there is no Bitwarden Browser extension
     installed. In case there still is a Bitwarden Extension please repeat step 3-4.
 6.  Quit and completely close Safari
 
@@ -213,7 +213,7 @@ the extension for every change, which is slower.
     npm run dist:safari:dmg
     ```
 
-2.  Open Safari and check Preferences to confirm that the extension is installed and enabled
+2.  Open Safari and check Settings to confirm that the extension is installed and enabled
 
 :::caution
 
@@ -224,7 +224,7 @@ You may need to
 
 To enable debugging:
 
-1.  Click “Preferences” and then click the “Advanced” tab
+1.  Click “Settings” and then click the “Advanced” tab
 2.  Enable “Show Develop menu in menu bar”
 
 You can debug the background page of the browser extension by clicking


### PR DESCRIPTION
## Objective

It appears Safari currently uses "Settings" terminology to refer to the documented menu options.

![Screenshot 2023-04-26 at 3 01 21 PM](https://user-images.githubusercontent.com/1556494/234679723-c25176db-3d47-40a7-a564-a546bad5ca2f.png)
