### PR TITLE
Pin except engines and peers

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,7 @@
     ":combinePatchMinorReleases",
     ":dependencyDashboard",
     ":maintainLockFilesWeekly",
-    ":pinVersions",
+    ":pinAllExceptPeerDependencies",
     ":prConcurrentLimit10",
     ":rebaseStalePrs",
     "schedule:weekends",


### PR DESCRIPTION
## Objective

Still pin dependencies but avoid peers e.g. the Node engine.
