### PR TITLE
Added environment change to the feature flag triggers

### DIFF
--- a/docs/contributing/featureflags.md
+++ b/docs/contributing/featureflags.md
@@ -158,6 +158,7 @@ interval:
 - On application startup.
 - Every hour after application startup.
 - On sync (both automatic and manual).
+- On environment change.
 
 Requesting a flag value from the services defined below will provide the consuming component with
 the most recent value from one of these retrieval events.


### PR DESCRIPTION
## Objective

Added environment change to what triggers flags to be re-fetched.

Changing the environment changes the API endpoint, which could theoretically change the LD environment (and thus the flag values).
