### PR TITLE
add Linux cert script steps

### DIFF
--- a/docs/getting-started/server/guide.md
+++ b/docs/getting-started/server/guide.md
@@ -234,7 +234,9 @@ Navigate to the `dev` folder in your server repo and perform the following comma
 
 2.  You will be prompted to enter a password 3 times. Create a complex password and type it into the
     `Export Password` field on each prompt. You will not be able to copy/paste.
-3.  You will receive output similar to the following. You will need to collect the generated certificate fingerprints for use in the [Configure User Secrets](#configure-user-secrets) section.
+3.  You will receive output similar to the following. You will need to collect the generated
+    certificate fingerprints for use in the [Configure User Secrets](#configure-user-secrets)
+    section.
 
     ```
     Certificate fingerprints:
@@ -255,7 +257,9 @@ Navigate to the `dev` folder in your server repo and perform the following comma
     .\create_certificates_windows.ps1
     ```
 
-2.  You will receive output similar to the following. You will need to collect the generated certificate fingerprints for use in the [Configure User Secrets](#configure-user-secrets) section.
+2.  You will receive output similar to the following. You will need to collect the generated
+    certificate fingerprints for use in the [Configure User Secrets](#configure-user-secrets)
+    section.
 
     ```
     PSParentPath: Microsoft.PowerShell.Security\Certificate::CurrentUser\My
@@ -274,7 +278,9 @@ Navigate to the `dev` folder in your server repo and perform the following comma
     ./create_certificates_linux.sh
     ```
 
-2.  You will receive output similar to the following. You will need to collect the generated certificate fingerprints for use in the [Configure User Secrets](#configure-user-secrets) section.
+2.  You will receive output similar to the following. You will need to collect the generated
+    certificate fingerprints for use in the [Configure User Secrets](#configure-user-secrets)
+    section.
 
     ```
     Certificate fingerprints:

--- a/docs/getting-started/server/guide.md
+++ b/docs/getting-started/server/guide.md
@@ -224,23 +224,6 @@ store.
 
 Navigate to the `dev` folder in your server repo and perform the following commands.
 
-### Linux
-
-1.  Generate the certificates and save them to your certificate store:
-
-    ```bash
-    ./create_certificates_linux.sh
-    ```
-
-2.  You will receive output similar to the following. You will need this information for the next
-    section.
-
-    ```
-    Certificate fingerprints:
-    Identity Server Dev: 0BE8A0072214AB37C6928968752F698EEC3A68B5
-    Data Protection Dev: C3A6CECAD3DB580F91A52FC9C767FE780300D8AB
-    ```
-
 ### MacOS
 
 1.  Generate the certificates and save them to your keychain:
@@ -283,6 +266,23 @@ Navigate to the `dev` folder in your server repo and perform the following comma
     ----------                                -------
     0BE8A0072214AB37C6928968752F698EEC3A68B5  CN=Bitwarden Identity Server Dev
     C3A6CECAD3DB580F91A52FC9C767FE780300D8AB  CN=Bitwarden Data Protection Dev
+    ```
+
+### Linux
+
+1.  Generate the certificates and save them to your certificate store:
+
+    ```bash
+    ./create_certificates_linux.sh
+    ```
+
+2.  You will receive output similar to the following. You will need this information for the next
+    section.
+
+    ```
+    Certificate fingerprints:
+    Identity Server Dev: 0BE8A0072214AB37C6928968752F698EEC3A68B5
+    Data Protection Dev: C3A6CECAD3DB580F91A52FC9C767FE780300D8AB
     ```
 
 <bitwarden>

--- a/docs/getting-started/server/guide.md
+++ b/docs/getting-started/server/guide.md
@@ -234,8 +234,7 @@ Navigate to the `dev` folder in your server repo and perform the following comma
 
 2.  You will be prompted to enter a password 3 times. Create a complex password and type it into the
     `Export Password` field on each prompt. You will not be able to copy/paste.
-3.  You will receive output similar to the following. You will need this information for the next
-    section.
+3.  You will receive output similar to the following. You will need to collect the generated certificate fingerprints for use in the [Configure User Secrets](#configure-user-secrets) section.
 
     ```
     Certificate fingerprints:
@@ -256,8 +255,7 @@ Navigate to the `dev` folder in your server repo and perform the following comma
     .\create_certificates_windows.ps1
     ```
 
-2.  You will receive output similar to the following. You will need this information for the next
-    section.
+2.  You will receive output similar to the following. You will need to collect the generated certificate fingerprints for use in the [Configure User Secrets](#configure-user-secrets) section.
 
     ```
     PSParentPath: Microsoft.PowerShell.Security\Certificate::CurrentUser\My
@@ -276,8 +274,7 @@ Navigate to the `dev` folder in your server repo and perform the following comma
     ./create_certificates_linux.sh
     ```
 
-2.  You will receive output similar to the following. You will need this information for the next
-    section.
+2.  You will receive output similar to the following. You will need to collect the generated certificate fingerprints for use in the [Configure User Secrets](#configure-user-secrets) section.
 
     ```
     Certificate fingerprints:

--- a/docs/getting-started/server/guide.md
+++ b/docs/getting-started/server/guide.md
@@ -224,6 +224,23 @@ store.
 
 Navigate to the `dev` folder in your server repo and perform the following commands.
 
+### Linux
+
+1.  Generate the certificates and save them to your certificate store:
+
+    ```bash
+    ./create_certificates_linux.sh
+    ```
+
+2.  You will receive output similar to the following. You will need this information for the next
+    section.
+
+    ```
+    Certificate fingerprints:
+    Identity Server Dev: 0BE8A0072214AB37C6928968752F698EEC3A68B5
+    Data Protection Dev: C3A6CECAD3DB580F91A52FC9C767FE780300D8AB
+    ```
+
 ### MacOS
 
 1.  Generate the certificates and save them to your keychain:


### PR DESCRIPTION
## Objective

Adds instructions for the newly-added `create_linux_certificate.sh` script from #https://github.com/bitwarden/server/pull/2941 
