### PR TITLE
Add Yubikey 2FA docs and other server-side docs cleanup

### DIFF
--- a/docs/contributing/user-secrets.md
+++ b/docs/contributing/user-secrets.md
@@ -2,10 +2,10 @@
 
 ## Manually editing user secrets
 
-We recommend using the automated helper script described in the [Server Setup Guide](./guide.md).
-However, you can manually edit or troubleshoot your user secrets using the instructions below. If
-you are manually editing using secrets, make sure to remember to copy your changes across to all
-projects if required.
+We recommend using the automated helper script described in the
+[Server Setup Guide](../getting-started/server/guide.md). However, you can manually edit or
+troubleshoot your user secrets using the instructions below. If you are manually editing using
+secrets, make sure to remember to copy your changes across to all projects if required.
 
 ### Editing user secrets - Visual Studio on Windows
 

--- a/docs/contributing/user-secrets.md
+++ b/docs/contributing/user-secrets.md
@@ -1,4 +1,4 @@
-# User Secrets Reference
+# Modifying User Secrets
 
 ## Manually editing user secrets
 

--- a/docs/getting-started/clients/web-vault/webauthn.mdx
+++ b/docs/getting-started/clients/web-vault/webauthn.mdx
@@ -67,7 +67,7 @@ Open the file with the text editor of your choice. And append the following line
 
 ### User Secrets
 
-In addition to modifying the host file, the [user secret](../../server/user-secrets.md)
+In addition to modifying the host file, the [user secret](../../../contributing/user-secrets.md)
 `globalSettings:baseServiceUri:vault` for API and Identity projects in the server needs to be
 created or updated to reflect the domain name. For example:
 

--- a/docs/getting-started/enterprise/key-connector.mdx
+++ b/docs/getting-started/enterprise/key-connector.mdx
@@ -102,7 +102,8 @@ configuration options are available in the
 
 :::info
 
-If you need help setting user secrets, see the [User Secrets Reference](../server/user-secrets.md).
+If you need help setting user secrets, see the
+[User Secrets Reference](../../contributing/user-secrets.md).
 
 :::
 

--- a/docs/getting-started/server/advanced-setup.md
+++ b/docs/getting-started/server/advanced-setup.md
@@ -1,6 +1,7 @@
 ---
 sidebar_custom_props:
   access: bitwarden
+sidebar_position: 2
 ---
 
 # Advanced Server Setup
@@ -96,6 +97,26 @@ you may need to test the PayPal integration specifically.
 
 Note: if you are testing sales tax, you will first have to create sales tax rates via the Admin
 portal.
+
+## YubiKey 2FA
+
+In order to locally test YubiKey 2FA, you must first configure your local user secrets with a
+ClientId and Key from Yubico. This is used to authenticate the API call to Yubico to validate the
+OTP provided.
+
+The steps for setting up your local server for YubiKey validation are:
+
+1. Acquire a ClientId and Key from Yubico [here](https://upgrade.yubico.com/getapikey/). Note that
+   this requires that you have a YubiKey in order to provide an OTP. If you do not have a YubiKey
+   please contact your manager.
+
+2. Update the `globalSettings:yubico:key` and `globalSettings:yubico:clientid` user secrets in the
+   `Identity` project. You can either use the [update script](./secrets/index.md) or manually
+   update:
+   ```bash
+      dotnet user-secrets set globalSettings:yubico:key [Key]
+      dotnet user-secrets set globalSettings:yubico:clientid [ClientId]
+   ```
 
 ## Reverse Proxy Setup
 

--- a/docs/getting-started/server/database/_category_.yml
+++ b/docs/getting-started/server/database/_category_.yml
@@ -1,2 +1,2 @@
 label: "Databases"
-position: 2
+position: 3

--- a/docs/getting-started/server/database/ef/index.mdx
+++ b/docs/getting-started/server/database/ef/index.mdx
@@ -51,7 +51,7 @@ chronological order.
 - A working local development server
 - Docker
 - A way to manage user secrets in the server project - see
-  [User Secrets](../../../contributing/user-secrets.md)
+  [User Secrets](../../../../contributing/user-secrets.md)
 - Database management software (see [tools recommendations](../../../tools/index.md#databases))
 - The `dotnet` CLI
 - The `dotnet` CLI [Entity Framework Core tool](https://docs.microsoft.com/en-us/ef/core/cli/dotnet)

--- a/docs/getting-started/server/database/ef/index.mdx
+++ b/docs/getting-started/server/database/ef/index.mdx
@@ -51,7 +51,7 @@ chronological order.
 - A working local development server
 - Docker
 - A way to manage user secrets in the server project - see
-  [User Secrets Reference](../../user-secrets.md)
+  [User Secrets](../../../contributing/user-secrets.md)
 - Database management software (see [tools recommendations](../../../tools/index.md#databases))
 - The `dotnet` CLI
 - The `dotnet` CLI [Entity Framework Core tool](https://docs.microsoft.com/en-us/ef/core/cli/dotnet)

--- a/docs/getting-started/server/events.md
+++ b/docs/getting-started/server/events.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 4
+---
+
 # Event Logging
 
 ## Requirements

--- a/docs/getting-started/server/portal.md
+++ b/docs/getting-started/server/portal.md
@@ -70,7 +70,7 @@ If not, please go back and configure it now.
 
 :::tip
 
-See [User Secrets Reference](./user-secrets.md) for how to configure your user secrets.
+See [User Secrets](../../contributing/user-secrets.md) for how to configure your user secrets.
 
 :::
 
@@ -96,7 +96,7 @@ each role:
 | Sales            | `adminSettings:role:sales`   | `sales@localhost`            |
 
 If you wish to change the membership for any role, you can
-[edit your user secrets](./user-secrets.md) to specify the desired value.
+[edit your user secrets](../../contributing/user-secrets.md) to specify the desired value.
 
 :::info
 

--- a/docs/getting-started/server/portal.md
+++ b/docs/getting-started/server/portal.md
@@ -1,12 +1,61 @@
-# Bitwarden Portal
+---
+sidebar_position: 8
+---
+
+# System Management Portal
+
+:::info Portal naming
+
+This documentation refers to the deployment of the `Admin` application in our `server` repository.
+To disambiguate this application from others in the Bitwarden landscape, we refer to it as follows:
+
+- For **Cloud-Hosted** Instances (internal to Bitwarden) &rarr; **Bitwarden Portal**
+- For **Self-Hosted** Instances &rarr; **System Management Portal**
+
+:::
+
+## Setup
+
+1.  Navigate to the `server/src/admin` directory.
+2.  Restore nuget packages:
+
+    ```bash
+    dotnet restore
+    ```
+
+3.  Install npm packages:
+
+    ```bash
+    npm ci
+    ```
+
+4.  Build the admin project:
+
+    ```bash
+    dotnet build
+    ```
+
+5.  Build out the `wwwroot` directory with the necessary stylesheets and libraries:
+
+    ```bash
+    npx gulp build
+    ```
+
+6.  Start the server:
+
+    ```bash
+    dotnet run
+    ```
+
+7.  Confirm it's working by using your favorite browser to navigate to the portal URL. By default,
+    this is [http://localhost:62911](http://localhost:62911).
 
 ## Configuring access
 
 ### Authentication
 
-Bitwarden Portal authentication is done entirely through a passwordless flow, using a link sent
-through email. The email address must be listed in the `adminSettings:admins` user secret to be
-authorized.
+Portal authentication is done entirely through a passwordless flow, using a link sent through email.
+The email address must be listed in the `adminSettings:admins` user secret to be authorized.
 
 If you’ve followed the [Server Setup Guide](./guide.md) this should already be configured, with the
 following accounts having access:
@@ -57,42 +106,6 @@ control on self-hosted deployments.
 :::
 
 </bitwarden>
-
-## Setup
-
-1.  Navigate to the `server/src/admin` directory.
-2.  Restore nuget packages:
-
-    ```bash
-    dotnet restore
-    ```
-
-3.  Install npm packages:
-
-    ```bash
-    npm ci
-    ```
-
-4.  Build the admin project:
-
-    ```bash
-    dotnet build
-    ```
-
-5.  Build out the `wwwroot` directory with the necessary stylesheets and libraries:
-
-    ```bash
-    npx gulp build
-    ```
-
-6.  Start the server:
-
-    ```bash
-    dotnet run
-    ```
-
-7.  Confirm it's working by using your favorite browser to navigate to the portal URL. By default,
-    this is [http://localhost:62911](http://localhost:62911).
 
 ## Logging in
 

--- a/docs/getting-started/server/scim.md
+++ b/docs/getting-started/server/scim.md
@@ -1,6 +1,7 @@
 ---
 sidebar_custom_props:
   access: bitwarden
+sidebar_position: 6
 ---
 
 # SCIM

--- a/docs/getting-started/server/secrets/_category_.yml
+++ b/docs/getting-started/server/secrets/_category_.yml
@@ -1,0 +1,2 @@
+label: "User Secrets"
+position: 11

--- a/docs/getting-started/server/secrets/index.md
+++ b/docs/getting-started/server/secrets/index.md
@@ -3,7 +3,7 @@ sidebar_custom_props:
   access: bitwarden
 ---
 
-# Secrets.json
+# User Secrets
 
 The server repository comes with it’s own `dev/secrets.json` file for community contributors.
 Internal Bitwarden developers will need a different user secrets file in order to properly emulate

--- a/docs/getting-started/server/self-hosted/_category_.yml
+++ b/docs/getting-started/server/self-hosted/_category_.yml
@@ -1,0 +1,2 @@
+label: "Self-Hosted"
+position: 7

--- a/docs/getting-started/server/self-hosted/index.md
+++ b/docs/getting-started/server/self-hosted/index.md
@@ -94,7 +94,8 @@ override section will apply instead of the value given in `GlobalSettings`.
 
 :::tip
 
-If you’re struggling to remember about user secrets, review [User Secrets](../user-secrets.md).
+If you’re struggling to remember about user secrets, review
+[User Secrets](../../../contributing/user-secrets.md).
 
 :::
 

--- a/docs/getting-started/server/sso/_category_.yml
+++ b/docs/getting-started/server/sso/_category_.yml
@@ -1,0 +1,2 @@
+label: "Single Sign-On (SSO)"
+position: 8

--- a/docs/getting-started/server/troubleshooting.md
+++ b/docs/getting-started/server/troubleshooting.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 10
+---
+
 # Troubleshooting
 
 ## MacOS

--- a/docs/getting-started/server/tunnel.md
+++ b/docs/getting-started/server/tunnel.md
@@ -1,6 +1,7 @@
 ---
 sidebar_custom_props:
   access: bitwarden
+sidebar_position: 5
 ---
 
 # Ingress Tunnels


### PR DESCRIPTION
## Objective

- Added documentation to the Advanced Server Setup for how to set up YubiKey 2FA in local development.  This came up on the Auth team with some recent tickets and I had to look in Slack history for recommendations.
- Added `sidebar_position` tags to all of the menu items for the Server setup so that they are alphabetized by title (after the setup guide, which is first)
- Moved User Secrets Reference from Getting Started to Contributing, as this felt like documentation that would be used while developing the code ("contributing") instead of initial setup where we have the helper script defined.