### PR TITLE
Add custom word, fix typo

### DIFF
--- a/custom-words.txt
+++ b/custom-words.txt
@@ -1,19 +1,23 @@
-# Custom dictionary for spellchecking
-# Before adding a word here, consider whether you can put it in a single (`) or multiline (```) code snippet instead,
-# as they are automatically ignored by the spellchecker
+# Custom dictionary for spellchecking. Before adding a word here, consider whether you can put
+# it in a single (`) or multiline (```) code snippet instead, as they are automatically ignored
+# by the spellchecker. Please keep the list sorted alphabetically.
 
 Bitwarden
 bytemark
+CODEOWNERS
 CQRS
 dockerized
+Gitter
 hotfix
-hotfixes
 hotfixed
+hotfixes
 inet
+IntelliJ
 Iterm
 jslib
 jumpcloud
 keychain
+keypair
 keyserver
 LDIF
 LLDB
@@ -21,35 +25,31 @@ Mailcatcher
 minio
 MVVM
 NGRX
+OIDCS
+oktapreview
 Omnisharp
+onboarded
 opid
 passcode
 passwordless
+pinentry
 PNSs
 proxied
+refactorings
 roadmap
 roadmaps
 SCIM
 SDET
+SDLC
+Serilog
 signtool
 signup
 sqlcmd
-TOTP
-Yellowpages
-CODEOWNERS
-SDLC
 subprocessor
-Gitter
-IntelliJ
-WCAG
-pinentry
-refactorings
 toolset
-keypair
-onboarded
-OIDCS
-oktapreview
+TOTP
+WCAG
 Xcodes.app
-YubiKey
+Yellowpages
 Yubico
-Serilog
+YubiKey

--- a/custom-words.txt
+++ b/custom-words.txt
@@ -52,3 +52,4 @@ oktapreview
 Xcodes.app
 YubiKey
 Yubico
+Serilog

--- a/docs/architecture/adr/0021-standard-output-logging.md
+++ b/docs/architecture/adr/0021-standard-output-logging.md
@@ -34,7 +34,7 @@ engineers across the board to improve what we deliver.
 
 - **Maintain current logging options** - Support what is available today for logging methods and
   expect those running the platform to configure what they need outside of it for log collection.
-- **Extend the plaform to specifically support Datadog** - A Serilog sink [exists][ddsink] and the
+- **Extend the platform to specifically support Datadog** - A Serilog sink [exists][ddsink] and the
   platform can send logs directly to Datadog.
 - **Consolidate logging providers** - Announce deprecation and migration plans for sinks not aligned
   with core needs and center on standard output for logs.


### PR DESCRIPTION
## Objective

Adds "Serilog" to custom words as lint failed once an ADR referring to it was merged. Also fixes a typo in the ADR.
