### PR TITLE
setup_secrets: Pass `-clear` as switch

### DIFF
--- a/docs/getting-started/server/guide.md
+++ b/docs/getting-started/server/guide.md
@@ -363,7 +363,7 @@ repository.
     pwsh setup_secrets.ps1
     ```
 
-The helper script also supports an optional `-clear` flag which removes all existing settings before
+The helper script also supports an optional `-clear` switch which removes all existing settings before
 re-applying them:
 
 ```bash

--- a/docs/getting-started/server/guide.md
+++ b/docs/getting-started/server/guide.md
@@ -363,8 +363,8 @@ repository.
     pwsh setup_secrets.ps1
     ```
 
-The helper script also supports an optional `-clear` switch which removes all existing settings before
-re-applying them:
+The helper script also supports an optional `-clear` switch which removes all existing settings
+before re-applying them:
 
 ```bash
 pwsh setup_secrets.ps1 -clear

--- a/docs/getting-started/server/guide.md
+++ b/docs/getting-started/server/guide.md
@@ -363,11 +363,11 @@ repository.
     pwsh setup_secrets.ps1
     ```
 
-The helper script also supports an optional flag which removes all existing settings before
+The helper script also supports an optional `-clear` flag which removes all existing settings before
 re-applying them:
 
 ```bash
-pwsh setup_secrets.ps1 -clear:$True
+pwsh setup_secrets.ps1 -clear
 ```
 
 ## Build and Run the Server

--- a/docs/getting-started/server/self-hosted/index.md
+++ b/docs/getting-started/server/self-hosted/index.md
@@ -122,7 +122,7 @@ After the updates to your `secrets.json` file in your self-hosted repo, apply yo
 running the following command:
 
 ```bash
-pwsh setup_secrets.ps1 -clear:$True
+pwsh setup_secrets.ps1 -clear
 ```
 
 You have now updated the user secrets for your self-hosted instance.


### PR DESCRIPTION
## Objective

While going through the onboarding, I had to reset my user secret several times. To do so, I was trying to use the `-clear` parameter as specified in the docs: `pwsh setup_secrets.ps1 -clear:$True`

However, I noticed [that this part of the script](https://github.com/bitwarden/server/blob/master/dev/setup_secrets.ps1#L15) was never being hit.

I changed `$True` to `true` and it started to work:

![image](https://github.com/bitwarden/contributing-docs/assets/144709477/72f9676a-176d-422b-a696-e9e8c81158dd)