### PR TITLE
use dash when running self-hosted dotnet profile

### DIFF
--- a/docs/getting-started/server/self-hosted/index.md
+++ b/docs/getting-started/server/self-hosted/index.md
@@ -251,7 +251,7 @@ To run self-hosted from the CLI, you will need to:
 3.  Start the Identity service:
 
     ```bash
-    dotnet run -—launch-profile Identity-SelfHost
+    dotnet run --launch-profile Identity-SelfHost
     ```
 
 4.  Test that the Identity service is alive by navigating to
@@ -266,7 +266,7 @@ To run self-hosted from the CLI, you will need to:
 6.  Start the Api Service:
 
     ```bash
-    dotnet run -—launch-profile Api-SelfHost
+    dotnet run --launch-profile Api-SelfHost
     ```
 
 7.  Test that the Api service is alive by navigating to


### PR DESCRIPTION
## Objective

The documentation for selecting the self-hosting profile incorrectly used an em dash (`—`) where it should have used a normal dash (`-`). This caused the dotnet runtime to select the wrong port when running instructions listed in the contributor docs. This commit replaces the em dash with a normal dash.
