### PR TITLE
[PM-4161] Fix build command on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ reflected live without having to restart the server.
 ## Build
 
 ```bash
-npm build
+npm run build
 ```
 
 This command generates static content into the `build` directory and can be served using any static


### PR DESCRIPTION
## Objective

<!--Describe what the purpose of this PR is.-->

This patch adds the missing `run` command (`npm run build`) to the Build step on the README.
Copying the command as is, results in the following error:
```
Unknown command: "build"                          
                                                  
Did you mean this?                                
    npm run build # run the "build" package script

To see a list of supported npm commands, run:
  npm help                                   

Process finished with exit code 1
```
