### PR TITLE
[PM-4407] docs: add cd command to setup instructions

### DIFF
--- a/docs/getting-started/clients/index.md
+++ b/docs/getting-started/clients/index.md
@@ -39,6 +39,7 @@ Before doing work on any of the clients, you need to clone and setup the `client
 2.  Install the dependencies:
 
     ```bash
+    cd clients
     npm ci
     ```
 


### PR DESCRIPTION
Update clients setup instructions

Add the current directory command to the "Install the dependencies" setup instructions step.

## Objective

This would make it so all necessary commands are included in the doc. And, by adding it into an existing step, brevity is maintained.
