### PR TITLE
Remove `docusaurus-lunr-search` overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,13 +50,6 @@
     "prettier": "3.1.0",
     "typescript": "5.2.2"
   },
-  "overrides": {
-    "docusaurus-lunr-search": {
-      "@docusaurus/core": "$@docusaurus/core",
-      "react": "$react",
-      "react-dom": "$react-dom"
-    }
-  },
   "browserslist": {
     "production": [
       ">0.5%",


### PR DESCRIPTION
## Objective

<!--Describe what the purpose of this PR is.-->

Remove the react overrides for `docusaurus-lunr-search` since they are no longer required with the latest version which was bumped in #231
