### PR TITLE
Remove Generate Certificates Section

### DIFF
--- a/docs/getting-started/server/guide.md
+++ b/docs/getting-started/server/guide.md
@@ -216,78 +216,6 @@ up-to-date. See [MSSQL Database](./database/mssql/index.md) for more information
 
 :::
 
-## Generate Certificates
-
-The next step is to create two self-signed certificates for local development. We provide a helper
-script that will generate these certificates and add them to your system’s keychain or certificate
-store.
-
-Navigate to the `dev` folder in your server repo and perform the following commands.
-
-### MacOS
-
-1.  Generate the certificates and save them to your keychain:
-
-    ```bash
-    sh create_certificates_mac.sh
-    ```
-
-2.  You will be prompted to enter a password 3 times. Create a complex password and type it into the
-    `Export Password` field on each prompt. You will not be able to copy/paste.
-3.  You will receive output similar to the following. You will need to collect the generated
-    certificate fingerprints for use in the [Configure User Secrets](#configure-user-secrets)
-    section.
-
-    ```
-    Certificate fingerprints:
-    Identity Server Dev: 0BE8A0072214AB37C6928968752F698EEC3A68B5
-    Data Protection Dev: C3A6CECAD3DB580F91A52FC9C767FE780300D8AB
-    ```
-
-4.  Open Keychain Access and go to your login keychain.
-5.  Double-click the `Bitwarden Data Protection Dev` and `Bitwarden Identity Server Dev`
-    certificates.
-6.  In each certificate, change the Trust settings to “Always Trust”.
-
-### Windows
-
-1.  Generate the certificates and save them to the Certificate Store:
-
-    ```bash
-    .\create_certificates_windows.ps1
-    ```
-
-2.  You will receive output similar to the following. You will need to collect the generated
-    certificate fingerprints for use in the [Configure User Secrets](#configure-user-secrets)
-    section.
-
-    ```
-    PSParentPath: Microsoft.PowerShell.Security\Certificate::CurrentUser\My
-
-    Thumbprint                                Subject
-    ----------                                -------
-    0BE8A0072214AB37C6928968752F698EEC3A68B5  CN=Bitwarden Identity Server Dev
-    C3A6CECAD3DB580F91A52FC9C767FE780300D8AB  CN=Bitwarden Data Protection Dev
-    ```
-
-### Linux
-
-1.  Generate the certificates and save them to your certificate store:
-
-    ```bash
-    ./create_certificates_linux.sh
-    ```
-
-2.  You will receive output similar to the following. You will need to collect the generated
-    certificate fingerprints for use in the [Configure User Secrets](#configure-user-secrets)
-    section.
-
-    ```
-    Certificate fingerprints:
-    Identity Server Dev: 0BE8A0072214AB37C6928968752F698EEC3A68B5
-    Data Protection Dev: C3A6CECAD3DB580F91A52FC9C767FE780300D8AB
-    ```
-
 <bitwarden>
 
 ## Install Licensing Certificate
@@ -342,10 +270,6 @@ repository.
 2.  Update `secrets.json` with your own values:
 
     - `sqlServer` > `connectionString`: insert your password where indicated
-    - `identityServer` > `certificateThumbprint`: insert your Identity certificate thumbprint from
-      the previous step
-    - `dataProtection` > `certificateThumbprint`: insert your Data Protection certificate thumbprint
-      from the previous step
 
     <community>
 

--- a/docs/getting-started/server/sso/local.md
+++ b/docs/getting-started/server/sso/local.md
@@ -61,10 +61,9 @@ This uses
     ./create_certificates_linux.sh
     ```
 
-    Paste the thumbprint, for example `0BE8A0072214AB37C6928968752F698EEC3A68B5`,
-    into your `secrets.json` file under `globalSettings` > `identityServer` >
-    `certificateThumbprint`. Update your secrets as
-    [shown here](../guide.md#configure-user-secrets).
+    Paste the thumbprint, for example `0BE8A0072214AB37C6928968752F698EEC3A68B5`, into your
+    `secrets.json` file under `globalSettings` > `identityServer` > `certificateThumbprint`. Update
+    your secrets as [shown here](../guide.md#configure-user-secrets).
 
 8.  Make a copy of the provided `authsources.php.example` file, which contains the configuration for
     your IdP users.

--- a/docs/getting-started/server/sso/local.md
+++ b/docs/getting-started/server/sso/local.md
@@ -61,9 +61,9 @@ This uses
     ./create_certificates_linux.sh
     ```
 
-    Then you need to paste the thumbprint, for example `0BE8A0072214AB37C6928968752F698EEC3A68B5`,
+    Paste the thumbprint, for example `0BE8A0072214AB37C6928968752F698EEC3A68B5`,
     into your `secrets.json` file under `globalSettings` > `identityServer` >
-    `certificateThumbprint`. Then you need to update your secrets as
+    `certificateThumbprint`. Update your secrets as
     [shown here](../guide.md#configure-user-secrets).
 
 8.  Make a copy of the provided `authsources.php.example` file, which contains the configuration for

--- a/docs/getting-started/server/sso/local.md
+++ b/docs/getting-started/server/sso/local.md
@@ -47,7 +47,26 @@ This uses
 
     :::
 
-7.  Make a copy of the provided `authsources.php.example` file, which contains the configuration for
+7.  (Optional) You may generate a certificate to sign SSO requests. You can do this with a script
+    made for your OS of choice.
+
+    ```bash
+    # Mac
+    ./create_certificates_mac.sh
+
+    # Windows
+    .\create_certificates_windows.ps1
+
+    # Linux
+    ./create_certificates_linux.sh
+    ```
+
+    Then you need to paste the thumbprint, for example `0BE8A0072214AB37C6928968752F698EEC3A68B5`,
+    into your `secrets.json` file under `globalSettings` > `identityServer` >
+    `certificateThumbprint`. Then you need to update your secrets as
+    [shown here](../guide.md#configure-user-secrets).
+
+8.  Make a copy of the provided `authsources.php.example` file, which contains the configuration for
     your IdP users.
 
     ```bash
@@ -59,13 +78,13 @@ This uses
     [here](https://github.com/kenchan0130/docker-simplesamlphp#advanced-usage) for more information
     about customizing this file.
 
-8.  Start the docker container:
+9.  Start the docker container:
 
     ```bash
     docker-compose --profile idp up -d
     ```
 
-9.  You can test your user configuration by navigating to
+10. You can test your user configuration by navigating to
     [http://localhost:8090/simplesaml](http://localhost:8090/simplesaml), then Authentication → test
     configured authentication sources → `example-userpass`. You should be able to login with the
     users you’ve configured.


### PR DESCRIPTION


## Objective

<!--Describe what the purpose of this PR is.-->
Remove the section that is no longer needed after bitwarden/server#3504 merged. This adds a new, optional, step to the local SAML SSO docs for using the certificate we used to require to optionally sign SSO requests.