### PR TITLE
Fixed IcePanel link

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -16,6 +16,6 @@ The documentation of our architecture is primarily done using an interactive too
 and can viewed [here](https://s.icepanel.io/ZcolpeB95vuenW/itdt), or below for an interactive view.
 
 It's recommend to start with one of the interactive
-[Tours](https://s.icepanel.io/ZcolpeB95vuenW/NnNG) of the Architecture.
+[Tours](https://s.icepanel.io/niB2pYJoHiNmdG/nt3i) of the Architecture.
 
-<iframe src="https://s.icepanel.io/ZcolpeB95vuenW/NnNG" height="800px" width="100%" frameBorder="0" title="Bitwarden - Bitwarden Architecture"></iframe>
+<iframe src="https://s.icepanel.io/niB2pYJoHiNmdG/nt3i" height="800px" width="100%" frameBorder="0" title="Bitwarden - Bitwarden Architecture"></iframe>

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -12,10 +12,8 @@ Since the web based clients mostly behave the same we will primarily cover the w
 client specific areas for the browser extension, desktop application and CLI. The Mobile application
 has its own codebase.
 
-The documentation of our architecture is primarily done using an interactive tool called IcePanel,
-and can viewed [here](https://s.icepanel.io/ZcolpeB95vuenW/itdt), or below for an interactive view.
-
+The documentation of our architecture is primarily done using an interactive tool called IcePanel.
 It's recommend to start with one of the interactive
-[Tours](https://s.icepanel.io/niB2pYJoHiNmdG/nt3i) of the Architecture.
+[Tours](https://s.icepanel.io/jCGiag2SENoQIU/EACm) of our application structure.
 
-<iframe src="https://s.icepanel.io/niB2pYJoHiNmdG/nt3i" height="800px" width="100%" frameBorder="0" title="Bitwarden - Bitwarden Architecture"></iframe>
+<iframe src="https://s.icepanel.io/jCGiag2SENoQIU/EACm" height="800px" width="100%" frameBorder="0" title="Bitwarden - Bitwarden Architecture"></iframe>

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -14,6 +14,4 @@ has its own codebase.
 
 The documentation of our architecture is primarily done using an interactive tool called IcePanel.
 It's recommend to start with one of the interactive
-[Tours](https://s.icepanel.io/jCGiag2SENoQIU/EACm) of our application structure.
-
-<iframe src="https://s.icepanel.io/jCGiag2SENoQIU/EACm" height="800px" width="100%" frameBorder="0" title="Bitwarden - Bitwarden Architecture"></iframe>
+[tours](https://s.icepanel.io/jCGiag2SENoQIU/EACm) of our application structure.


### PR DESCRIPTION
## Objective

Fixed obsolete link to IcePanel diagram.

Due to the way that shared links are generated in IcePanel, generating a static link would invalidate the dynamic link.  I opted to remove the static link reference and just use the dynamic one instead.
