### PR TITLE
Alphabetizing the custom-words.txt file

### DIFF
--- a/custom-words.txt
+++ b/custom-words.txt
@@ -4,6 +4,7 @@
 
 Bitwarden
 bytemark
+clickjacking
 CODEOWNERS
 CQRS
 dockerized
@@ -11,6 +12,7 @@ Gitter
 hotfix
 hotfixed
 hotfixes
+iframes
 inet
 IntelliJ
 Iterm
@@ -31,6 +33,7 @@ Omnisharp
 onboarded
 opid
 OTLP
+owasp
 passcode
 passwordless
 pinentry
@@ -39,6 +42,7 @@ proxied
 refactorings
 roadmap
 roadmaps
+sandboxed
 SCIM
 SDET
 SDLC
@@ -55,7 +59,3 @@ xmldoc
 Yellowpages
 Yubico
 YubiKey
-sandboxed
-iframes
-owasp
-clickjacking


### PR DESCRIPTION
## Objective

While merging in the updates to the autofill documentation, I neglected to alphabetize the added custom words created for the document. This PR addresses that.
