### PR TITLE
Clarify instructions for local SAML SSO

### DIFF
--- a/docs/getting-started/server/sso/local.md
+++ b/docs/getting-started/server/sso/local.md
@@ -33,7 +33,8 @@ This uses
     ```
 
 6.  Open your `.env` file and set the following environment variables using the "SP Entity ID" and
-    "Assertion Consumer Service (ACS) URL" values from the SSO configuration page opened in step #2:
+    "Assertion Consumer Service (ACS) URL" values from the SSO configuration page opened in step #4
+    above:
 
     ```bash
     IDP_SP_ENTITY_ID={SP Entity ID}

--- a/docs/getting-started/server/sso/local.md
+++ b/docs/getting-started/server/sso/local.md
@@ -13,7 +13,7 @@ This uses
     - API
     - SSO (located at `server/bitwarden_license/src/Sso`)
 
-2.  Local web client running
+2.  Local web client running.
 
 ## Configure IdP
 

--- a/docs/getting-started/server/sso/local.md
+++ b/docs/getting-started/server/sso/local.md
@@ -17,11 +17,11 @@ This uses
 
 ## Configure IdP
 
-1.  Open your local web client and navigate to your organization → Settings → Single Sign-On
+1.  Open your local web client and navigate to your organization → Settings → Single Sign-On.
 
-2.  Tick the "Allow SSO authentication" box
+2.  Tick the "Allow SSO authentication" box.
 
-3.  Come up with and enter an SSO Identifier
+3.  Come up with and enter an SSO Identifier.
 
 4.  Select "SAML 2.0" as the SSO type. Don't save or exit this page yet, you'll need to come back to
     it later.
@@ -90,7 +90,7 @@ This uses
 
 ## Configure Bitwarden
 
-1.  Go back to your window with the SSO configuration page open
+1.  Go back to your window with the SSO configuration page open.
 2.  Complete the following values in the SAML Identity Provider Configuration section:
 
     1.  Entity ID:
@@ -103,7 +103,7 @@ This uses
         ```
     3.  X509 Public Certificate: get this by opening a new tab and navigating to the Entity ID URL
         above. It will open (or download) an XML file. Copy and paste the value _between_ the
-        `<ds:X509Certificate>` tags (it should look like a B64 encoded string)
+        `<ds:X509Certificate>` tags (it should look like a B64 encoded string).
 
 3.  Save your SSO configuration
 

--- a/docs/getting-started/server/sso/local.md
+++ b/docs/getting-started/server/sso/local.md
@@ -85,7 +85,7 @@ This uses
 
 10. You can test your user configuration by navigating to
     [http://localhost:8090/simplesaml](http://localhost:8090/simplesaml), then Authentication → test
-    configured authentication sources → `example-userpass`. You should be able to login with the
+    configured authentication sources → `example-userpass`. You should be able to log in with the
     users you’ve configured.
 
 ## Configure Bitwarden

--- a/docs/getting-started/server/sso/local.md
+++ b/docs/getting-started/server/sso/local.md
@@ -17,14 +17,14 @@ This uses
 
 ## Configure IdP
 
-1.  Open your local web vault and navigate to your organization → Settings → Single Sign-On
+1.  Open your local web client and navigate to your organization → Settings → Single Sign-On
 
 2.  Tick the "Allow SSO authentication" box
 
 3.  Come up with and enter an SSO Identifier
 
 4.  Select "SAML 2.0" as the SSO type. Don't save or exit this page yet, you'll need to come back to
-    it later
+    it later.
 
 5.  Open a new terminal and navigate to the `dev` folder in your server repository, e.g.
 
@@ -32,12 +32,12 @@ This uses
     cd ~/Projects/server/dev
     ```
 
-6.  Open your `.env` file and set the following environment variables, based on the "SP Entity ID"
-    and "Assertion Consumer Service (ACS) URL" values on the web vault SSO configuration page:
+6.  Open your `.env` file and set the following environment variables using the "SP Entity ID" and
+    "Assertion Consumer Service (ACS) URL" values from the SSO configuration page opened in step #2:
 
     ```bash
-    IDP_SP_ENTITY_ID=http://localhost:51822/saml2
-    IDP_SP_ACS_URL=http://localhost:51822/saml2/yourOrgIdHere/Acs
+    IDP_SP_ENTITY_ID={SP Entity ID}
+    IDP_SP_ACS_URL={ACS URL}
     ```
 
     :::note


### PR DESCRIPTION
## Objective

With https://github.com/bitwarden/clients/pull/7117, we added an SSO configuration option (defaulting to enabled) that  creates a specific Entity ID in the URL.

In the setup documentation, the URL didn't reflect that change.  Despite the instructions to copy from the values in the web client, the presence of the "copy" UI made it very easy to copy the incorrect URL and set the environment variable incorrectly.

Instead of adding "{yourOrgIdHere}" as was already in the ACS URL, I opted to completely remove any reference to the URLs themselves in the script, so that users will use the values in the UI.  This will prevent us from having to keep the documentation in sync with any future URL structure changes.
