### PR TITLE
Added optional constructor parameter and updated mapping instructions.

### DIFF
--- a/docs/architecture/deep-dives/state/index.md
+++ b/docs/architecture/deep-dives/state/index.md
@@ -401,14 +401,15 @@ automatically through the `Jsonify<T>` given to your in your `deserializer` meth
 
 When moving state from `StateService` to the state provider pattern, you'll be asked to create a
 `StateDefinition` for your state. This should be informed by the storage location that was being
-used in the `StateService`. You can use the cross-reference below to map between the two. |
-`StateService` Option | Desired Storage Location | Desired Web (HTML) Storage Location |
-`StateDefinition` Equivalent | | --- | --- | --- | --- | |`defaultOnDiskOptions()` | Disk | Session
-| `new StateDefinition("state", "disk")` | |`defaultOnDiskLocalOptions()` | Disk | Local |
-`new StateDefinition("state", "disk", { web: "disk-local" })` | |`defaultOnDiskMemoryOptions()` |
-Disk | Session | `new StateDefinition("state", "disk")` | |`defaultInMemoryOptions()` | Memory |
-Memory | `new StateDefinition("state", "memory")` | |`defaultSecureStorageOptions()` | Disk | N/A |
-No migration path currently |
+used in the `StateService`. You can use the cross-reference below to map between the two.
+
+| `StateService` Option           | Desired Storage Location | Desired Web Storage Location | `StateDefinition` Equivalent                                  |
+| ------------------------------- | ------------------------ | ---------------------------- | ------------------------------------------------------------- |
+| `defaultOnDiskOptions()`        | Disk                     | Session                      | `new StateDefinition("state", "disk")`                        |
+| `defaultOnDiskLocalOptions()`   | Disk                     | Local                        | `new StateDefinition("state", "disk", { web: "disk-local" })` |
+| `defaultOnDiskMemoryOptions()`  | Disk                     | Session                      | `new StateDefinition("state", "disk")`                        |
+| `defaultInMemoryOptions()`      | Memory                   | Memory                       | `new StateDefinition("state", "memory")`                      |
+| `defaultSecureStorageOptions()` | Disk                     | N/A                          | No migration path currently                                   |
 
 #### Clarifying `defaultOnDiskMemoryOptions()`
 

--- a/docs/architecture/deep-dives/state/index.md
+++ b/docs/architecture/deep-dives/state/index.md
@@ -401,7 +401,8 @@ automatically through the `Jsonify<T>` given to your in your `deserializer` meth
 
 When moving state from `StateService` to the state provider pattern, you'll be asked to create a
 `StateDefinition` for your state. This should be informed by the storage location that was being
-used in the `StateService`. You can use the cross-reference below to map between the two.
+used in the `StateService`. You can use the cross-reference below to help you decide how to map
+between the two.
 
 | `StateService` Option           | Desired Storage Location | Desired Web Storage Location | `StateDefinition` Equivalent                                  |
 | ------------------------------- | ------------------------ | ---------------------------- | ------------------------------------------------------------- |

--- a/docs/architecture/deep-dives/state/index.md
+++ b/docs/architecture/deep-dives/state/index.md
@@ -416,8 +416,9 @@ between the two.
 
 Despite its name, `defaultOnDiskMemoryOptions()` results in the web client storing the state in
 session storage, _not_ in memory. As such, the equivalent `StateDefinition` storage location is
-`"disk"`; since `"disk"` maps to session storage on the web client there is no reason to say
-`{ web: "memory" }` if your previous state service options used `defaultOnDiskMemoryOptions()`.
+`"disk"`; since `"disk"` maps to session storage on the web client there is no reason to specify
+`{ web: "memory" }` as a client-specific storage location if your previous state service options
+used `defaultOnDiskMemoryOptions()`.
 
 However, we do have cases in which the `StateService` is extended in a particular client and
 different storage options are defined there for a given element of state. For example,


### PR DESCRIPTION
## Objective

Added additional documentation for new constructor parameter as well as a mapping table to help with migration.

📓 Note the destination of this PR is @justindbaur's larger body of work updating the state provider framework.  I wanted to make sure I had a review before it made it into this larger set of changes, hence the separate PR.
