### PR TITLE
[PM-6143] Fix custom bitwarden and community components

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,21 +64,21 @@ across sessions.
 
 ![Context switcher](.github/dropdown.png)
 
-In order to write content that targets different context please use the `<community>` and
-`<bitwarden>` tags as demonstrated below.
+In order to write content that targets different context please use the `<Community>` and
+`<Bitwarden>` tags as demonstrated below.
 
 ```md
-<community>
+<Community>
 
 This content is shown only to community contributors.
 
-</community>
+</Community>
 
-<bitwarden>
+<Bitwarden>
 
 This content is shown only to bitwarden contributors.
 
-</bitwarden>
+</Bitwarden>
 ```
 
 The technical implementation uses a custom context called `devMode` which is persisted to local

--- a/docs/contributing/accessibility/accessibility.mdx
+++ b/docs/contributing/accessibility/accessibility.mdx
@@ -11,7 +11,7 @@ point for common “gotchas” that can limit the accessibility of a new feature
 guidelines on accessibility, visit the official
 [WCAG site](https://www.w3.org/WAI/WCAG21/Understanding/).
 
-<bitwarden>
+<Bitwarden>
 
 :::info
 
@@ -20,7 +20,7 @@ Additional resources on accessibility at Bitwarden can be found on
 
 :::
 
-</bitwarden>
+</Bitwarden>
 
 ## Visual Presentation
 

--- a/docs/contributing/database-migrations/edd.mdx
+++ b/docs/contributing/database-migrations/edd.mdx
@@ -17,7 +17,7 @@ Bitwarden also needs to support:
 To fulfill these additional requirements the database schema **must** support the previous release
 of the server.
 
-<bitwarden>
+<Bitwarden>
 
 :::note
 
@@ -25,7 +25,7 @@ For background on this decision please see the [Evolutionary Database Design RFD
 
 :::
 
-</bitwarden>
+</Bitwarden>
 
 ## Design
 

--- a/docs/contributing/pull-requests/code-review.md
+++ b/docs/contributing/pull-requests/code-review.md
@@ -29,8 +29,8 @@ You can find more tips for PR review here:
 ## Reviewing
 
 If you feel that someone else has good knowledge of the code you are reviewing, please feel free to
-reach out to them or add them as a reviewer. <bitwarden>Bitwarden developers can use the [SME
-Yellowpages][sme-yellowpages] to look for knowledge area experts.</bitwarden>
+reach out to them or add them as a reviewer. <Bitwarden>Bitwarden developers can use the [SME
+Yellowpages][sme-yellowpages] to look for knowledge area experts.</Bitwarden>
 
 Please do **not** approve code you do not understand the implications of. Comments and concerns are
 always welcome! For example, it’s okay to leave some general comments or feedback, while also saying

--- a/docs/contributing/pull-requests/index.md
+++ b/docs/contributing/pull-requests/index.md
@@ -8,7 +8,7 @@ Pull Requests are the primary mechanism we use to write software. GitHub has som
 [documentation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests)
 on using the Pull Request feature.
 
-<community>
+<Community>
 
 ## Fork
 
@@ -36,7 +36,7 @@ This will allow you to pull in upstream changes easily by running.
 git fetch upstream
 ```
 
-</community>
+</Community>
 
 ## Branch
 
@@ -46,7 +46,7 @@ working with other contributors we typically branch off a long-lived feature bra
 feature branches allow us to break up a single feature into multiple PRs, which can be reviewed
 individually but tested and released together.
 
-<community>
+<Community>
 
 As a community contributor you can use the following command to branch directly from the _upstream_
 `main` branch.
@@ -55,9 +55,9 @@ As a community contributor you can use the following command to branch directly 
 git checkout -b feature/example
 ```
 
-</community>
+</Community>
 
-<bitwarden>
+<Bitwarden>
 
 As a Bitwarden contributor you should branch of `origin/main`, this ensures that the branch is
 always based of the latest upstream `main` even if the local `main` is out of date.
@@ -68,7 +68,7 @@ git checkout -b <team>/<issue-number>/<brief-description> -t origin/main
 
 Our branching strategy is described in detail [here](branching.md).
 
-</bitwarden>
+</Bitwarden>
 
 ## Commit
 
@@ -100,13 +100,13 @@ changes” to a PR forcing the reviewer to start over again.
 ## Creating a pull request
 
 The Bitwarden repositories have a _Pull Request template_ which should be followed. This will ensure
-the PR review goes smoothly since it will provide context to the reviewer.<community> Once a
+the PR review goes smoothly since it will provide context to the reviewer.<Community> Once a
 community PR has been created, it will be automatically be linked to an internal Jira ticket. The
-internal ticket is used for prioritization and tracking purposes.</community><bitwarden> When
+internal ticket is used for prioritization and tracking purposes.</Community><Bitwarden> When
 creating the PR include a Jira ticket reference so the reviewer can gain all context on the work as
-well as links to any associated PRs in other repositories.</bitwarden>
+well as links to any associated PRs in other repositories.</Bitwarden>
 
-<bitwarden>
+<Bitwarden>
 
 ### Tagging reviewers
 
@@ -140,11 +140,11 @@ been addressed.
 **When you are ready for a reviewer to revisit your changes, you should request a re-review.** This
 will notify the reviewer and ensure a prompt response.
 
-</bitwarden>
+</Bitwarden>
 
 ## Reviewing the pull request
 
-<bitwarden>
+<Bitwarden>
 
 At Bitwarden, we believe that the act of reviewing PRs is a critically important part of each
 engineer's job. It is as important, if not more important, than the act of writing code.
@@ -190,15 +190,15 @@ pull request, the author should reach out to the reviewing team via their Slack 
 
 :::
 
-</bitwarden>
+</Bitwarden>
 
-<community>
+<Community>
 
 Once a Community PR has been created a Bitwarden developer will perform a code review. While we try
 to this in a reasonable time frame, please understand that we have internal roadmaps and priorities
 that may delay this process.
 
-</community>
+</Community>
 
 ### How to perform a review
 

--- a/docs/getting-started/clients/browser/index.md
+++ b/docs/getting-started/clients/browser/index.md
@@ -233,7 +233,7 @@ right-clicking it while it is open and clicking "Inspect Element".
 
 This should be enough for most debugging and testing, unless you're working in native code.
 
-<bitwarden>
+<Bitwarden>
 
 :::info
 
@@ -243,4 +243,4 @@ extension. It may be useful for debugging if you’re having difficulty.
 
 :::
 
-</bitwarden>
+</Bitwarden>

--- a/docs/getting-started/clients/mobile/android/index.md
+++ b/docs/getting-started/clients/mobile/android/index.md
@@ -80,14 +80,14 @@ The default configuration for the Android app is to register itself to the same 
 Bitwarden's QA Cloud. This means that if you try to debug the app using the production endpoints you
 won't be able to receive Live Sync updates or Passwordless login requests.
 
-<bitwarden>
+<Bitwarden>
 
 So, in order to receive notifications while debugging, you have two options:
 
 - Use QA Cloud endpoints for the Api and Identity, or
 - Use a local server setup where the Api is connected to QA Azure Notification Hub
 
-</bitwarden>
+</Bitwarden>
 
 ### Testing Passwordless Locally
 

--- a/docs/getting-started/clients/mobile/index.md
+++ b/docs/getting-started/clients/mobile/index.md
@@ -18,31 +18,31 @@ See the [Android Mobile app](./android/index.md) page to set up an Android devel
 
 ## iOS Development
 
-<bitwarden>
+<Bitwarden>
 
 See the [iOS Mobile app](./ios/index.mdx) page to set up an iOS development environment.
 
-</bitwarden>
+</Bitwarden>
 
-<community>
+<Community>
 
 Unfortunately, iOS development requires provisioning profiles and other capabilities only available
 to internal team members. We do not have any documentation for community developers at this time.
 
-</community>
+</Community>
 
 ## watchOS Development
 
-<bitwarden>
+<Bitwarden>
 
 See the [watchOS app](./watchos) page to set up an watchOS development environment.
 
-</bitwarden>
+</Bitwarden>
 
-<community>
+<Community>
 
 Unfortunately, watchOS development requires provisioning profiles and other capabilities only
 available to internal team members. We do not have any documentation for community developers at
 this time.
 
-</community>
+</Community>

--- a/docs/getting-started/clients/web-vault/index.mdx
+++ b/docs/getting-started/clients/web-vault/index.mdx
@@ -31,23 +31,23 @@ mkcert -cert-file dev-server.local.pem -key-file dev-server.local.pem localhost 
 
 1.  Build and run the Web Vault.
 
-  <community>
+  <Community>
 
   ```bash
   cd apps/web
   npm run build:oss:watch
   ```
 
-  </community>
+  </Community>
 
-  <bitwarden>
+  <Bitwarden>
 
   ```bash
   cd apps/web
   npm run build:bit:watch
   ```
 
-  </bitwarden>
+  </Bitwarden>
 
     Which will target the local bitwarden instance. See [Official Server](#official-server) for
     information on how to target official servers.
@@ -55,7 +55,7 @@ mkcert -cert-file dev-server.local.pem -key-file dev-server.local.pem localhost 
 2.  Open your browser and navigate to `https://localhost:8080`. You should see the Bitwarden Log In Screen.
 
 3. If you'd like to take this a bit further, start your local server and have MailCatcher set up. Now let's create an account and verify it.
-  
+
     - Create a new account. This could be a fake email
     - Log into the new account
     - Click on Verify Email Address
@@ -83,21 +83,21 @@ default ports). You can use the official Bitwarden server instead or configure c
 To use the official Bitwarden server, follow the build instructions above, but run the Web Vault
 using the following command:
 
-<community>
+<Community>
 
 ```bash
 ENV=cloud npm run build:oss:watch
 ```
 
-</community>
+</Community>
 
-<bitwarden>
+<Bitwarden>
 
 ```bash
 ENV=cloud npm run build:bit:watch
 ```
 
-</bitwarden>
+</Bitwarden>
 
 ### Custom Endpoints
 

--- a/docs/getting-started/enterprise/directory-connector/index.mdx
+++ b/docs/getting-started/enterprise/directory-connector/index.mdx
@@ -82,9 +82,9 @@ setting up:
 These are both LDAP directory services. If you need to test another type, you should be able to find
 a platform offering a free tier of that service.
 
-<bitwarden>
+<Bitwarden>
 
 If you need to test Active Directory (not Azure AD), contact the Integration Engineering team for
 remote access to a test AD instance.
 
-</bitwarden>
+</Bitwarden>

--- a/docs/getting-started/enterprise/key-connector.mdx
+++ b/docs/getting-started/enterprise/key-connector.mdx
@@ -12,20 +12,20 @@ understand how it works.
 
 ## Requirements
 
-<bitwarden>
+<Bitwarden>
 
 - A [local development server](../server/guide.md), running in the
   [self-hosted configuration](../server/self-hosted/index.md)
 - An enterprise organization with [Single Sign-On](../server/sso/index.md) configured
 
-</bitwarden>
+</Bitwarden>
 
-<community>
+<Community>
 
 - A [local development server](../server/guide.md) running in the self-hosted configuration
 - An enterprise organization with SSO configured
 
-</community>
+</Community>
 
 - [Web vault](../clients/web-vault) running locally
 - [.NET Core 5.0 SDK](https://www.microsoft.com/net/download/core)

--- a/docs/getting-started/server/guide.md
+++ b/docs/getting-started/server/guide.md
@@ -89,7 +89,7 @@ facilitate easily customization.
     Using PowerShell, navigate to the cloned server repo location, into the `dev` folder and run the
     docker command below.
 
-    <community>
+    <Community>
 
     ```bash
     docker compose --profile mssql --profile mail up -d
@@ -98,9 +98,9 @@ facilitate easily customization.
     Which starts the MSSQL and local mail server containers, which should be suitable for most
     community contributions.
 
-    </community>
+    </Community>
 
-    <bitwarden>
+    <Bitwarden>
 
     ```bash
     docker compose --profile cloud --profile mail up -d
@@ -109,7 +109,7 @@ facilitate easily customization.
     Which starts MSSQL, mail, and Azurite container. The additional Azurite container is required to
     emulate Azure used by the Bitwarden cloud environment.
 
-    </bitwarden>
+    </Bitwarden>
 
 After you’ve run the `docker compose` command, you can use the
 [Docker Dashboard](https://docs.docker.com/desktop/dashboard/) to manage your containers. You should
@@ -216,7 +216,7 @@ up-to-date. See [MSSQL Database](./database/mssql/index.md) for more information
 
 :::
 
-<bitwarden>
+<Bitwarden>
 
 ## Install Licensing Certificate
 
@@ -231,7 +231,7 @@ done by double-clicking on the downloaded certificate.
 5. The dev.pfx file will ask for a password. You can get this by clicking and opening the Licensing
    Certificate - Dev item in the vault
 
-</bitwarden>
+</Bitwarden>
 
 ## Configure User Secrets
 
@@ -246,7 +246,7 @@ repository.
 1.  Get a template `secrets.json`. We need to get an initial version of `secrets.json`, which you
     will modify for your own secrets values.
 
-    <community>
+    <Community>
 
     Navigate to the `dev` folder in your server repo and copy the example `secrets.json` file.
 
@@ -254,9 +254,9 @@ repository.
     cp secrets.json.example secrets.json
     ```
 
-    </community>
+    </Community>
 
-    <bitwarden>
+    <Bitwarden>
 
     - Copy the user secrets file from the shared Development collection (Your Bitwarden Vault) into
       the `dev` folder.
@@ -265,20 +265,20 @@ repository.
     - This `secrets.json` is configured to use the dockerized Azurite and MailCatcher instances and
       is recommended for this guide.
 
-    </bitwarden>
+    </Bitwarden>
 
 2.  Update `secrets.json` with your own values:
 
     - `sqlServer` > `connectionString`: insert your password where indicated
 
-    <community>
+    <Community>
 
     - `installation` > `id` and `key`:
       [request a hosting installation Id and Key](https://bitwarden.com/host/) and insert them here
     - `licenseDirectory`: set this to an empty directory, this is where uploaded license files will
       be stored.
 
-    </community>
+    </Community>
 
 3.  Once you have your `secrets.json` complete, run the below command to add the secrets to each
     Bitwarden server project.

--- a/docs/getting-started/server/portal.md
+++ b/docs/getting-started/server/portal.md
@@ -74,7 +74,7 @@ See [User Secrets](../../contributing/user-secrets.md) for how to configure your
 
 :::
 
-<bitwarden>
+<Bitwarden>
 
 ### Authorization
 
@@ -105,7 +105,7 @@ control on self-hosted deployments.
 
 :::
 
-</bitwarden>
+</Bitwarden>
 
 ## Logging in
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -27,7 +27,7 @@ we recommend progressing through the documentation in the following order.
 
 If you're having trouble following these instructions, don't panic.
 
-<bitwarden>
+<Bitwarden>
 
 - The [Bitwarden Help Center](https://bitwarden.com/help/) is an excellent resource to learn about
   the different features of our software and configuration options.
@@ -36,16 +36,16 @@ If you're having trouble following these instructions, don't panic.
 - Ask in the `#team-eng` Slack channel for general setup help
 - Ask in the `#code` Slack channel for questions about coding architecture, patterns and problems
 
-</bitwarden>
+</Bitwarden>
 
-<community>
+<Community>
 
 - The [Bitwarden Help Center](https://bitwarden.com/help/) is an excellent resource to learn about
   the different features of our software and configuration options.
 - Ask for help from the community in the [Community Forums](https://community.bitwarden.com)
 - Ask the dev team on the official [Gitter chat](https://gitter.im/bitwarden/Lobby)
 
-</community>
+</Community>
 
 ## Help make this documentation better
 

--- a/src/theme/MDXComponents.tsx
+++ b/src/theme/MDXComponents.tsx
@@ -8,7 +8,7 @@ export default {
   ...MDXComponents,
 
   // Custom mapping
-  bitwarden: Bitwarden,
-  community: Community,
+  Bitwarden: Bitwarden,
+  Community: Community,
   AdrTable: AdrTable,
 };


### PR DESCRIPTION
## Objective

In mixed content formats (like msx), lowercase tags will typically be interpreted as literal HTML (valid or not), even if there is an available React Component defined with lower casing. This was causing the custom `<bitwarden>` and `<community>` tags to render literally instead of using react to conditionally render the wrapped children.

![Screenshot 2024-02-07 at 12 26 51 PM](https://github.com/bitwarden/contributing-docs/assets/1556494/be618bc5-1930-4f6c-b2fd-6103f3ceb5fb)

This causes the Bitwarden/Community developer filter to not work, rendering all content in either tag, regardless of the state returned by the `useDevMode` hook.


## Code Changes
Uppercasing the jsx tags and references in `src/theme/MDXComponents.tsx` resolves the issue

### Before
![before](https://github.com/bitwarden/contributing-docs/assets/1556494/dcfaed65-d05d-4722-b3a3-7968278b6197)

### After
![after](https://github.com/bitwarden/contributing-docs/assets/1556494/bed6680a-9317-4a60-9a78-02e65a636499)
