### PR TITLE
Clarify where BitWarden License is installed in Mac Keychain

### DIFF
--- a/docs/getting-started/server/guide.md
+++ b/docs/getting-started/server/guide.md
@@ -224,20 +224,20 @@ To run your local server environment as a licensed instance, you will need to do
 `Licensing Certificate - Dev` from the shared Engineering collection and install it. This can be
 done by double-clicking on the downloaded certificate.
 
+:::note
+
+Mac users: When prompted to save the downloaded certificate and PFX file in Keychain Access be sure
+to select "Default Keychain > login" from the dropdown otherwise they will not be found when
+attempting to "Build and Run the Server".
+
+:::
+
 1. Log in to your company-issued Bitwarden account
 2. On the "Vaults" page, scroll down to the "Licensing Certificate - Dev" item
 3. View attachments and download both files
 4. Go to Keychain Access and set the dev.cer certificate to "Always Trust"
 5. The dev.pfx file will ask for a password. You can get this by clicking and opening the Licensing
    Certificate - Dev item in the vault
-
-:::note
-
-Mac Users: When prompted to save the downloaded certificate and pfx file in Mac Keychain be sure to
-select "Default Keychain > login" from the dropdown. Otherwise they will not be found when
-attempting to "Build and Run the Server".
-
-:::
 
 </Bitwarden>
 

--- a/docs/getting-started/server/guide.md
+++ b/docs/getting-started/server/guide.md
@@ -235,7 +235,7 @@ done by double-clicking on the downloaded certificate.
 
 Mac Users: When prompted to save the downloaded certificate and pfx file in Mac Keychain be sure to
 select "Default Keychain > login" from the dropdown. Otherwise they will not be found when
-attempting to Build and Run the Server.
+attempting to "Build and Run the Server".
 
 :::
 

--- a/docs/getting-started/server/guide.md
+++ b/docs/getting-started/server/guide.md
@@ -231,6 +231,14 @@ done by double-clicking on the downloaded certificate.
 5. The dev.pfx file will ask for a password. You can get this by clicking and opening the Licensing
    Certificate - Dev item in the vault
 
+:::note
+
+Mac Users: When prompted to save the downloaded certificate and pfx file in Mac Keychain be sure to
+select "Default Keychain > login" from the dropdown. Otherwise they will not be found when
+attempting to Build and Run the Server.
+
+:::
+
 </Bitwarden>
 
 ## Configure User Secrets


### PR DESCRIPTION
## Objective

When BitWarden Developers are installing Licensing for local & self hosted instances, Mac Keychain allows the license and key to be installed under different groups and defaults to "Local Items". The current guide does not make it immediately obvious that they must be stored under "Default Keychains > login" in order for it to be recognized during "Build and Run the Server" steps.

This change adds a note in step "Install Licensing Certificate" that explicitly states where the licensing files should be saved.
