### PR TITLE
Consistently use capitalization of 'macOS' in documentation

### DIFF
--- a/docs/getting-started/clients/browser/biometric.mdx
+++ b/docs/getting-started/clients/browser/biometric.mdx
@@ -25,7 +25,7 @@ _Supported:_
 _Not Supported:_
 
 - Firefox Versions 86 and earlier
-- Side-loaded MacOS Desktop Apps
+- Side-loaded macOS Desktop Apps
 - Linux OS
 
 ## General Setup Steps

--- a/docs/getting-started/clients/browser/index.md
+++ b/docs/getting-started/clients/browser/index.md
@@ -238,7 +238,7 @@ This should be enough for most debugging and testing, unless you're working in n
 :::info
 
 [Deploying](https://bitwarden.atlassian.net/wiki/spaces/EN/pages/166396366/Deploying) has more
-information about building, packing and signing the MacOS Desktop client, including the Browser
+information about building, packing and signing the macOS Desktop client, including the Browser
 extension. It may be useful for debugging if you’re having difficulty.
 
 :::

--- a/docs/getting-started/clients/mobile/ios/index.mdx
+++ b/docs/getting-started/clients/mobile/ios/index.mdx
@@ -37,7 +37,7 @@ import TabItem from "@theme/TabItem";
    any of this is missing, ask the IT department (@IT #tech-support in slack) for the additional
    roles / permissions
 
-## MacOS Setup
+## macOS Setup
 
 Next, you need to get your Mac environment set up for building and running the Bitwarden iOS mobile
 project. This requires creating the necessary developer provisioning profiles for code signing and
@@ -221,7 +221,7 @@ Next, we need to configure your Visual Studio environment for development.
    Mac), go to your Mac and open System Preferences > Sharing and look for the ".local" address of
    your machine
 
-4. Provide your Username and Password for MacOS when prompted
+4. Provide your Username and Password for macOS when prompted
 
 5. Once paired, close the Pair Mac window
 

--- a/docs/getting-started/clients/mobile/watchos/index.mdx
+++ b/docs/getting-started/clients/mobile/watchos/index.mdx
@@ -16,7 +16,7 @@ ease the sync between devices and the debugging communication.
 It's recommended to read the [Watch Architecture](../../../../architecture/mobile-clients/watchOS)
 as well.
 
-## MacOS Setup
+## macOS Setup
 
 Having followed the macOS setup of iOS, no additional configuration is needed given that when the
 project is opened in XCode it will automatically have the provisioning profiles set up.

--- a/docs/getting-started/enterprise/key-connector.mdx
+++ b/docs/getting-started/enterprise/key-connector.mdx
@@ -30,9 +30,9 @@ understand how it works.
 - [Web vault](../clients/web-vault) running locally
 - [.NET Core 5.0 SDK](https://www.microsoft.com/net/download/core)
 
-### MacOS
+### macOS
 
-MacOS requires updated SSL libraries, otherwise you will receive the error "No usable version of
+macOS requires updated SSL libraries, otherwise you will receive the error "No usable version of
 libssl was found".
 
 <Tabs>
@@ -188,7 +188,7 @@ If running on ARM based Mac you may need to use `/usr/local/share/dotnet/x64/dot
 
 :::
 
-The `--configuration` flag is required for MacOS to use the right SSL libraries.
+The `--configuration` flag is required for macOS to use the right SSL libraries.
 
    </TabItem>
 </Tabs>

--- a/docs/getting-started/server/guide.md
+++ b/docs/getting-started/server/guide.md
@@ -370,7 +370,7 @@ debugger.
 To debug:
 
 - On Windows, right-click on each project > click **Debug** > click **Start New Instance**
-- On MacOS, right-click each project > click **Start Debugging Project**
+- On macOS, right-click each project > click **Start Debugging Project**
 
 ### Rider
 

--- a/docs/getting-started/server/troubleshooting.md
+++ b/docs/getting-started/server/troubleshooting.md
@@ -4,7 +4,7 @@ sidebar_position: 10
 
 # Troubleshooting
 
-## MacOS
+## macOS
 
 ### AppleCFErrorCryptographicException
 

--- a/docs/getting-started/tools/index.md
+++ b/docs/getting-started/tools/index.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 ## Operating System
 
 All Bitwarden developers are issued with a MacBook. The tooling recommendations and instructions in
-this documentation assume that you’re using MacOS. This may require some adaptation if you’re using
+this documentation assume that you’re using macOS. This may require some adaptation if you’re using
 a different operating system.
 
 ## Recommended tools


### PR DESCRIPTION
## Objective

Throughout the documentation, we were sometimes referring to the Mac operating system as "MacOS" and "macOS". The recommendation in the [Apple Style Guide](https://support.apple.com/en-my/guide/applestyleguide/apsg72b28652/1.0/web/1.0#apd246e83209) is "macOS", and while that document is intended primarily for Apple communications, it seems reasonable for us to match their branding.

This change updates this accordingly.