### PR TITLE
Clarify that changing secrets.json requires reloading the secrets

### DIFF
--- a/docs/getting-started/server/database/ef/index.mdx
+++ b/docs/getting-started/server/database/ef/index.mdx
@@ -135,7 +135,7 @@ Source path. Use the file location selected in [Database Setup](#database-setup)
 :::note
 
 After making changes to your `secrets.json` file, remember to run `pwsh setup_secrets.ps1 -clear` to
-make sure the changes are incorporated.
+make sure the changes take effect.
 
 :::
 

--- a/docs/getting-started/server/database/ef/index.mdx
+++ b/docs/getting-started/server/database/ef/index.mdx
@@ -132,6 +132,13 @@ Source path. Use the file location selected in [Database Setup](#database-setup)
 </TabItem>
 </Tabs>
 
+:::note
+
+After making changes to your `secrets.json` file, remember to run `pwsh setup_secrets.ps1 -clear` to
+make sure the changes are incorporated.
+
+:::
+
 ### Migrations
 
 <Tabs

--- a/docs/getting-started/server/database/ef/index.mdx
+++ b/docs/getting-started/server/database/ef/index.mdx
@@ -134,8 +134,8 @@ Source path. Use the file location selected in [Database Setup](#database-setup)
 
 :::note
 
-After making changes to your `secrets.json` file, remember to run `pwsh setup_secrets.ps1 -clear` to
-make sure the changes take effect.
+After making changes to your `secrets.json` file, remember to run `pwsh setup_secrets.ps1 -clear` so
+that the changes take effect.
 
 :::
 


### PR DESCRIPTION
## Objective

When I was trying to get my local Bitwarden server working with an EF database, I ran into the problem that changing the `secrets.json` file alone was insufficient. After a bit of time, I figured out that calling the `setup_secrets` script again fixed the issue.

It therefore seems reasonable to me to include a note here to remind people to run that script if modifying properties to run the server with an EF.

### Caveats
- It is possible that this is not actually necessary, and there is some other better solution, in which case the docs should be updated to that effect
- I only used `pwsh setup_secrets.ps1 -clear`, and that worked; it's possible the `-clear` flag is unnecessary, though it seems reasonable especially if the `databaseProvider` property might be removed (to return to MSSQL)
