### PR TITLE
New ADR statuses

### DIFF
--- a/docs/architecture/adr/0001-reactive-forms.md
+++ b/docs/architecture/adr/0001-reactive-forms.md
@@ -1,6 +1,6 @@
 ---
 adr: "0001"
-status: In progress
+status: Accepted
 date: 2022-05-28
 tags: [clients, angular, forms]
 ---

--- a/docs/architecture/adr/0002-public-module-npm-packages.md
+++ b/docs/architecture/adr/0002-public-module-npm-packages.md
@@ -1,6 +1,6 @@
 ---
 adr: "0002"
-status: In progress
+status: Accepted
 date: 2022-06-02
 tags: [clients]
 ---

--- a/docs/architecture/adr/0003-observable-data-services.md
+++ b/docs/architecture/adr/0003-observable-data-services.md
@@ -1,6 +1,6 @@
 ---
 adr: "0003"
-status: In progress
+status: Accepted
 date: 2022-06-30
 tags: [clients, angular]
 ---

--- a/docs/architecture/adr/0004-refactor-state-service.md
+++ b/docs/architecture/adr/0004-refactor-state-service.md
@@ -1,6 +1,6 @@
 ---
 adr: "0004"
-status: In progress
+status: Accepted
 date: 2022-06-30
 tags: [clients, angular]
 ---

--- a/docs/architecture/adr/0005-refactor-api-service.md
+++ b/docs/architecture/adr/0005-refactor-api-service.md
@@ -1,6 +1,6 @@
 ---
 adr: "0005"
-status: In progress
+status: Accepted
 date: 2022-07-08
 tags: [clients, angular]
 ---

--- a/docs/architecture/adr/0006-clients-use-jest-mocks.md
+++ b/docs/architecture/adr/0006-clients-use-jest-mocks.md
@@ -1,6 +1,6 @@
 ---
 adr: "0006"
-status: Done
+status: Accepted
 date: 2022-07-18
 tags: [clients, tests]
 ---

--- a/docs/architecture/adr/0007-manifest-v3-browser-memory-caching.md
+++ b/docs/architecture/adr/0007-manifest-v3-browser-memory-caching.md
@@ -1,6 +1,6 @@
 ---
 adr: "0007"
-status: In progress
+status: Accepted
 date: 2022-07-12
 tags: [browser, angular]
 ---

--- a/docs/architecture/adr/0008-server-CQRS-pattern.md
+++ b/docs/architecture/adr/0008-server-CQRS-pattern.md
@@ -1,6 +1,6 @@
 ---
 adr: "0008"
-status: In progress
+status: Accepted
 date: 2022-07-15
 tags: [server]
 ---

--- a/docs/architecture/adr/0009-angular-composition-over-inheritance.md
+++ b/docs/architecture/adr/0009-angular-composition-over-inheritance.md
@@ -1,6 +1,6 @@
 ---
 adr: "0009"
-status: In progress
+status: Accepted
 date: 2022-07-25
 tags: [clients, angular]
 ---

--- a/docs/architecture/adr/0010-angular-ngmodules.md
+++ b/docs/architecture/adr/0010-angular-ngmodules.md
@@ -1,6 +1,6 @@
 ---
 adr: "0010"
-status: In progress
+status: Accepted
 date: 2022-07-25
 tags: [clients, angular]
 ---

--- a/docs/architecture/adr/0011-angular-folder-structure.md
+++ b/docs/architecture/adr/0011-angular-folder-structure.md
@@ -1,7 +1,7 @@
 ---
 title: 0011 - Angular folder structure
 adr: "0011"
-status: In progress
+status: Accepted
 date: 2022-07-25
 tags: [clients, angular]
 ---

--- a/docs/architecture/adr/0012-angular-filename-convention.md
+++ b/docs/architecture/adr/0012-angular-filename-convention.md
@@ -1,7 +1,7 @@
 ---
 title: 0012 - Angular filename convention
 adr: "0012"
-status: In progress
+status: Accepted
 date: 2022-08-23
 tags: [clients, angular]
 ---

--- a/docs/architecture/adr/0013-deprecate-global-request-response-models.md
+++ b/docs/architecture/adr/0013-deprecate-global-request-response-models.md
@@ -1,6 +1,6 @@
 ---
 adr: "0013"
-status: In progress
+status: Accepted
 date: 2022-09-16
 tags: [clients, angular]
 ---

--- a/docs/architecture/adr/0014-typescript-strict.md
+++ b/docs/architecture/adr/0014-typescript-strict.md
@@ -1,6 +1,6 @@
 ---
 adr: "0014"
-status: In progress
+status: Accepted
 date: 2022-09-02
 tags: [clients, typescript]
 ---

--- a/docs/architecture/adr/0015-short-lived-browser-services.md
+++ b/docs/architecture/adr/0015-short-lived-browser-services.md
@@ -1,6 +1,6 @@
 ---
 adr: "0015"
-status: In progress
+status: Accepted
 date: 2022-12-09
 tags: [browser, clients, typescript]
 ---

--- a/docs/architecture/adr/0016-decryption-in-views.md
+++ b/docs/architecture/adr/0016-decryption-in-views.md
@@ -7,6 +7,8 @@ tags: [clients, typescript]
 
 # 0016 - Move Decryption and Encryption to Views
 
+<AdrTable frontMatter={frontMatter}></AdrTable>
+
 ## Context and Problem Statement
 
 Bitwarden has a couple of different models for representing data described in detail in

--- a/docs/architecture/adr/0016-decryption-in-views.md
+++ b/docs/architecture/adr/0016-decryption-in-views.md
@@ -1,6 +1,6 @@
 ---
 adr: "0016"
-status: In progress
+status: Accepted
 date: 2022-11-28
 tags: [clients, typescript]
 ---

--- a/docs/architecture/adr/0017-watchOS-use-swift.md
+++ b/docs/architecture/adr/0017-watchOS-use-swift.md
@@ -1,6 +1,6 @@
 ---
 adr: "0017"
-status: Done
+status: Accepted
 date: 2022-12-30
 tags: [mobile, watchOS]
 ---

--- a/docs/architecture/adr/0018-feature-management.md
+++ b/docs/architecture/adr/0018-feature-management.md
@@ -1,6 +1,6 @@
 ---
 adr: "0018"
-status: Done
+status: Accepted
 date: 2023-02-01
 tags: [server]
 ---

--- a/docs/architecture/adr/0019-adopt-web-push.md
+++ b/docs/architecture/adr/0019-adopt-web-push.md
@@ -1,6 +1,6 @@
 ---
 adr: "0019"
-status: In progress
+status: Accepted
 date: 2023-02-06
 tags: [server, clients, browser, notifications]
 ---

--- a/docs/architecture/adr/0020-observability-with-opentelemetry.md
+++ b/docs/architecture/adr/0020-observability-with-opentelemetry.md
@@ -1,6 +1,6 @@
 ---
 adr: "0020"
-status: In progress
+status: Accepted
 date: 2023-07-13
 tags: [server]
 ---

--- a/docs/architecture/adr/0021-standard-output-logging.md
+++ b/docs/architecture/adr/0021-standard-output-logging.md
@@ -1,6 +1,6 @@
 ---
 adr: "0021"
-status: In progress
+status: Accepted
 date: 2023-07-13
 tags: [server]
 ---

--- a/docs/architecture/adr/index.mdx
+++ b/docs/architecture/adr/index.mdx
@@ -23,9 +23,16 @@ The AD will also serve as a base for proposing and planning technical debt.
 
 ### Status definition
 
-- **In progress** - ADR is ratified and we are in progress of adopting it across the project(s).
-- **Standard** - ADR is implemented and assumed to be standard.
-- **Abandoned** - ADR is abandoned, and/or replaced by another ADR.
+ADRs are:
+
+- **Proposed:** In the process of being written and reviewed. Expected to change before merging to
+  one of the statuses below.
+- **Accepted:** Ratified and expected to be utilized going forward, or already complete depending on
+  context and time of reading.
+- **Rejected:** Not accepted but recorded to preserve history and the decision-making process; for
+  reference. Likely seldom used as many ADs will transform during review.
+- **Deprecated:** No longer expected to be in place, or abandoned.
+- **Superseded:** Replaced by a future ADR, with appropriate annotation to the successor(s).
 
 ### Tags
 

--- a/docs/architecture/adr/index.mdx
+++ b/docs/architecture/adr/index.mdx
@@ -46,6 +46,9 @@ decisions, it's important to us to keep the process open to suggestions from any
 anyone is free to open a PR _suggesting_ an AD. The suggestions will then be discussed to reach a
 general consensus amongst leadership before being adopted.
 
+Once an ADR is recorded and accepted it is expected that any related documentation around
+architecture, deep dives, process, etc. is updated to reflect the decision(s) made.
+
 ## ADRs
 
 <DocCardList />

--- a/docs/architecture/adr/index.mdx
+++ b/docs/architecture/adr/index.mdx
@@ -41,10 +41,10 @@ and/or _server_). Feel free to create more tags should the need arise.
 
 ## Process
 
-While the process was originally created primarily for leads to discuss architectural decisions,
-it's important to us to keep the process open to suggestions from anyone. To that end, anyone is
-free to open a PR _suggesting_ an AD. The suggestions will then be discussed to reach a general
-consensus between the leads before being adopted.
+While the process was originally created primarily for engineering leaders to discuss architectural
+decisions, it's important to us to keep the process open to suggestions from anyone. To that end,
+anyone is free to open a PR _suggesting_ an AD. The suggestions will then be discussed to reach a
+general consensus amongst leadership before being adopted.
 
 ## ADRs
 

--- a/src/components/AdrTable.tsx
+++ b/src/components/AdrTable.tsx
@@ -7,7 +7,11 @@ const formatDate = (date: Date) => {
 };
 
 const badgeColors = {
-  "In progress": "primary",
+  Proposed: "primary",
+  Accepted: "success",
+  Rejected: "danger",
+  Deprecated: "warning",
+  Superseded: "warning",
 };
 
 export default function AdrTable({ frontMatter }): JSX.Element {
@@ -22,7 +26,7 @@ export default function AdrTable({ frontMatter }): JSX.Element {
           <tr>
             <th>Status:</th>
             <td>
-              <span className={`badge badge--${badgeColors[frontMatter.status] ?? "primary"}`}>
+              <span className={`badge badge-${badgeColors[frontMatter.status] ?? "secondary"}`}>
                 {frontMatter.status?.toUpperCase()}
               </span>
             </td>

--- a/src/components/AdrTable.tsx
+++ b/src/components/AdrTable.tsx
@@ -26,7 +26,7 @@ export default function AdrTable({ frontMatter }): JSX.Element {
           <tr>
             <th>Status:</th>
             <td>
-              <span className={`badge badge-${badgeColors[frontMatter.status] ?? "secondary"}`}>
+              <span className={`badge badge--${badgeColors[frontMatter.status] ?? "secondary"}`}>
                 {frontMatter.status?.toUpperCase()}
               </span>
             </td>


### PR DESCRIPTION
## Objective

Uses new statuses for ADRs. After some review of what others do with them and how we have a number ourselves that we consider ratified but not necessarily appropriate to declare "done", it's better to represent acceptance and future state.
