### PR TITLE
SM-1200: Rename service account to machine account

### DIFF
--- a/docs/architecture/adr/0018-feature-management.md
+++ b/docs/architecture/adr/0018-feature-management.md
@@ -62,10 +62,11 @@ upon startup, login, when their local configuration is updated, and when sync ev
 
 Contexts will be established that communicate to the API using supported clients. Said contexts will
 be available within the service provider for specific targeting as desired. Contexts will be
-established for the user, organization, and service account, with unique IDs for the entity as a key
-and other details as needed. Context attributes when needed can be marked as private to avoid
-spillover to the service provider, and the provider will be added if needed to the [subprocessor
-list][subprocessors] with respective communication should PII be used.
+established for the user, organization, and machine account (previously known as service account),
+with unique IDs for the entity as a key and other details as needed. Context attributes when needed
+can be marked as private to avoid spillover to the service provider, and the provider will be added
+if needed to the [subprocessor list][subprocessors] with respective communication should PII be
+used.
 
 Compile-time configuration will be converted wherever possible to use the feature management service
 provider. SDK access to the service provider will be segmented by environment; some features may

--- a/docs/contributing/feature-flags.md
+++ b/docs/contributing/feature-flags.md
@@ -13,7 +13,8 @@ highlights:
 
 - [Context](https://github.com/bitwarden/server/blob/main/src/Core/Context/ICurrentContext.cs) is
   provided when requesting the state of a flag. We currently allow targeting on user, organization,
-  and service account. Only the IDs are sent to LaunchDarkly to avoid PII sharing.
+  and machine account (previously known as service account). Only the IDs are sent to LaunchDarkly
+  to avoid PII sharing.
 - All available feature flag states are provided to clients calling the
   [configuration API](https://github.com/bitwarden/server/blob/main/src/Api/Models/Response/ConfigResponseModel.cs).
 - Environments (production, QA, and development for now) exist to segment flag states further. This

--- a/docs/getting-started/sdk/secrets-manager/integrations/kubernetes.mdx
+++ b/docs/getting-started/sdk/secrets-manager/integrations/kubernetes.mdx
@@ -64,8 +64,8 @@ You will also need:
 - A
   [Bitwarden organization with Secrets Manager](https://bitwarden.com/help/sign-up-for-secrets-manager/).
   You will need the organization ID GUID for your organization.
-- An [access token](https://bitwarden.com/help/access-tokens/) for a Secrets Manager service account
-  tied to the projects you want to pull.
+- An [access token](https://bitwarden.com/help/access-tokens/) for a Secrets Manager machine account
+  (previously known as service account) tied to the projects you want to pull.
 
 ## Setup and configuration
 
@@ -203,9 +203,9 @@ The secret values are stored as Base64 encoded strings.
 
 Think of the BitwardenSecret object as the synchronization settings that will be used by the
 operator to create and synchronize a Kubernetes secret. This Kubernetes secret will live inside of a
-namespace and will be injected with the data available to a Secrets Manager service account. The
-resulting Kubernetes secret will include all secrets that a specific service account has access to.
-The sample file
+namespace and will be injected with the data available to a Secrets Manager machine account
+(previously known as service account). The resulting Kubernetes secret will include all secrets that
+a specific machine account has access to. The sample file
 ([config/samples/k8s_v1_bitwardensecret.yaml](https://github.com/bitwarden/sm-kubernetes/blob/main/src/sm-operator/config/samples/k8s_v1_bitwardensecret.yaml))
 provides the basic structure of a BitwardenSecret manifest. The key settings that you will want to
 update are listed below:
@@ -215,7 +215,7 @@ update are listed below:
 - **spec.secretName**: The name of the Kubernetes secret that will be created and injected with
   Secrets Manager data.
 - **spec.authToken**: The name of a secret inside of the Kubernetes namespace that the
-  BitwardenSecrets object is being deployed into that contains the Secrets Manager service account
+  BitwardenSecrets object is being deployed into that contains the Secrets Manager machine account
   authorization token being used to access secrets.
 
 Secrets Manager does not guarantee unique secret names across projects, so by default secrets will


### PR DESCRIPTION
## Objective

Rename variants of service account to machine account. This is a bit more complicated for the contributing docs repository, as developers need to know the following:

- "machine account" is synonymous with "service account"
- Front facing text of "service account" is being changed to "machine account"
- We are not renaming service accounts in the code at this time
