### PR TITLE
Added the intended end of the sentence in the PR update section

### DIFF
--- a/docs/contributing/dependencies/index.md
+++ b/docs/contributing/dependencies/index.md
@@ -111,7 +111,7 @@ What this means is that if you do need to make changes during review, you should
 of the PR through the rest of the workflow and not leave the PR open for an extended period.
 
 If you do want Renovate to take over managing the dependencies in the PR again, you can request that
-by checking the
+by selecting the "rebase/retry" checkbox on the PR description.
 
 ![Updating a PR](image.png)
 


### PR DESCRIPTION
## 🎟️ Tracking

Addressing typo in PR https://github.com/bitwarden/contributing-docs/pull/387.

## 📔 Objective

Fixed typo in earlier PR that removed the end of the sentence.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
