### PR TITLE
Authorization deep dive amendments

### DIFF
--- a/docs/architecture/deep-dives/authorization.md
+++ b/docs/architecture/deep-dives/authorization.md
@@ -151,12 +151,12 @@ await _cipherRepository.DeleteAsync(cipher);
 Some queries return all resources of a type within a particular scope. For example, rather than
 returning a specific cipher (or a specific set of ciphers), return all ciphers for an organization.
 
-In this case, we use a strongly typed `OrganizationIdResource` wrapper around the organization ID as
+In this case, we use a strongly typed `OrganizationResource` wrapper around the organization ID as
 the resource. The operation describes the scope of the read. This requires a separate handler to be
 defined for this combination of resource and operation.
 
 ```cs
-var authorizationResult = await _authorizationService.AuthorizeAsync(User, new OrganizationIdResource(orgId), CipherOperations.ReadAllForOrganization);
+var authorizationResult = await _authorizationService.AuthorizeAsync(User, new OrganizationResource(orgId), CipherOperations.ReadAllForOrganization);
 if (!authorizationResult.Succeeded)
 {
   throw new NotFoundError();
@@ -182,13 +182,6 @@ Call your authorization logic from controllers. This keeps authorization an API 
 does not complicate the business logic contained in commands and queries. It also means that every
 controller endpoint should have a call to `IAuthorizationService`, which is easier to look for in
 code review.
-
-Some commands have complex authorization requirements. For example, a single command may affect
-multiple resources with different requirements, or the authorization requirements may depend on the
-parameters of the request. In this case, you can implement the `IGetAuthorizationRequirements`
-interface in your command. This returns a sequence of resource-requirement pairs which can then be
-given to `IAuthorizationService` to authorize. This is useful for keeping the controller endpoint
-simple while maintaining separation from core business logic.
 
 You should ensure that your calls to `IAuthorizationService` cover the scope of all business logic
 executed by the endpoint.

--- a/docs/architecture/deep-dives/authorization.md
+++ b/docs/architecture/deep-dives/authorization.md
@@ -178,10 +178,10 @@ var result = await _cipherRepository.ReadManyByUserId(userId);
 
 ### Check authorization in controllers
 
-Call your authorization logic from controllers. This keeps authorization an API layer concern and
-does not complicate the business logic contained in commands and queries. It also means that every
-controller endpoint should have a call to `IAuthorizationService`, which is easier to look for in
-code review.
+Call your authorization logic from controller endpoints. This ensures that authorization is done
+upfront and avoids complicating the business logic contained in the core layer. It also means that
+every controller endpoint should have a call to `IAuthorizationService`, which is easier to look for
+in code review.
 
 You should ensure that your calls to `IAuthorizationService` cover the scope of all business logic
 executed by the endpoint.

--- a/docs/architecture/deep-dives/authorization.md
+++ b/docs/architecture/deep-dives/authorization.md
@@ -77,17 +77,16 @@ if (!authorizationResult.Succeeded)
 }
 ```
 
+We provide an extension method, `AuthorizeOrThrowAsync`, which encapsulates this pattern of throwing
+a `NotFoundError` if the check fails.
+
 ### Create
 
 Instantiate the object you want to save, then pass it to `AuthorizationService`.
 
 ```cs
 var cipher = cipherRequestModel.ToCipher();
-var authorizationResult = await _authorizationService.AuthorizeAsync(User, cipher, CipherOperations.Create);
-if (!authorizationResult.Succeeded)
-{
-  throw new NotFoundException();
-}
+await _authorizationService.AuthorizeOrThrowAsync(User, cipher, CipherOperations.Create);
 
 await _cipherRepository.Create(cipher);
 ```
@@ -98,11 +97,7 @@ Read the object from the database, then pass it to `AuthorizationService`.
 
 ```cs
 var cipher = _cipherRepository.GetByIdAsync(id);
-var authorizationResult = await _authorizationService.AuthorizeAsync(User, cipher, CipherOperations.Read);
-if (!authorizationResult.Succeeded)
-{
-  throw new NotFoundException();
-}
+await _authorizationService.AuthorizeOrThrowAsync(User, cipher, CipherOperations.Read);
 
 return new CipherResponseModel(cipher);
 ```
@@ -113,11 +108,7 @@ Read the **unedited** object from the database, then pass it to `AuthorizationSe
 
 ```cs
 var cipher = _cipherRepository.GetByIdAsync(id);
-var authorizationResult = await _authorizationService.AuthorizeAsync(User, cipher, CipherOperations.Update);
-if (!authorizationResult.Succeeded)
-{
-  throw new NotFoundException();
-}
+await _authorizationService.AuthorizeOrThrowAsync(User, cipher, CipherOperations.Update);
 
 // Only update the cipher after the authorization check has passed
 cipher.Name = cipherRequest.Name;
@@ -137,11 +128,7 @@ Read the object from the database, then pass it to `AuthorizationService`.
 
 ```cs
 var cipher = _cipherRepository.GetByIdAsync(id);
-var authorizationResult = await _authorizationService.AuthorizeAsync(User, cipher, CipherOperations.Delete);
-if (!authorizationResult.Succeeded)
-{
-  throw new NotFoundException();
-}
+await _authorizationService.AuthorizeOrThrowAsync(User, cipher, CipherOperations.Delete);
 
 await _cipherRepository.DeleteAsync(cipher);
 ```
@@ -157,11 +144,7 @@ to be defined for this combination of resource and operation.
 
 ```cs
 var organization = _currentContext.GetOrganization(orgId);
-var authorizationResult = await _authorizationService.AuthorizeAsync(User, organization, CipherOperations.ReadAllForOrganization);
-if (!authorizationResult.Succeeded)
-{
-  throw new NotFoundException();
-}
+await _authorizationService.AuthorizeOrThrowAsync(User, organization, CipherOperations.ReadAllForOrganization);
 
 var result = await _cipherRepository.ReadManyByOrganizationId(orgId);
 ```

--- a/docs/architecture/deep-dives/authorization.md
+++ b/docs/architecture/deep-dives/authorization.md
@@ -159,19 +159,17 @@ var result = await _cipherRepository.ReadManyByUserId(userId);
 
 ## Guidelines
 
-### Check authorization in controllers
+### Where to check authorization
 
-Call your authorization logic from controller endpoints. This ensures that authorization is done
-upfront and avoids complicating the business logic contained in the core layer. It also means that
-every controller endpoint should have a call to `IAuthorizationService`, which is easier to look for
-in code review.
-
-You should ensure that your calls to `IAuthorizationService` cover the scope of all business logic
-executed by the endpoint.
+You can check authorization in the controller endpoint or in the query/command class itself. There
+are arguments for both and this remains an open topic. However, aim to be clear and consistent in
+your approach. The most important thing is that you have authorized all actions being undertaken by
+the user.
 
 ### Operation names
 
-Define your basic operations using the CRUD verbs - create, read, update, delete.
+Define your basic operations using the CRUD verbs - create, read, update, delete. You may add
+additional operations if required by your domain.
 
 ### Use 404 errors
 

--- a/docs/architecture/deep-dives/authorization.md
+++ b/docs/architecture/deep-dives/authorization.md
@@ -149,14 +149,15 @@ await _cipherRepository.DeleteAsync(cipher);
 ### Bulk reads
 
 Some queries return all resources of a type within a particular scope. For example, rather than
-returning a specific cipher (or a specific set of ciphers), return all ciphers for an organization.
+returning a specific cipher, return all ciphers for an organization.
 
-In this case, we use a strongly typed `OrganizationResource` wrapper around the organization ID as
-the resource. The operation describes the scope of the read. This requires a separate handler to be
-defined for this combination of resource and operation.
+In this example, the `CurrentContextOrganization` object (representing the organization) becomes the
+resource, and the operation describes the scope of the read. This would require a separate handler
+to be defined for this combination of resource and operation.
 
 ```cs
-var authorizationResult = await _authorizationService.AuthorizeAsync(User, new OrganizationResource(orgId), CipherOperations.ReadAllForOrganization);
+var organization = _currentContext.GetOrganization(orgId);
+var authorizationResult = await _authorizationService.AuthorizeAsync(User, organization, CipherOperations.ReadAllForOrganization);
 if (!authorizationResult.Succeeded)
 {
   throw new NotFoundException();
@@ -166,8 +167,7 @@ var result = await _cipherRepository.ReadManyByOrganizationId(orgId);
 ```
 
 Sometimes the database query itself is scoped to the user, such that no additional authorization
-check is required or even possible. (Although it should still require authentication.) If this is
-not obvious from the context, note this in a comment:
+check is required or even possible. If this is not obvious from the context, note this in a comment:
 
 ```cs
 // Note: this database call only returns the user's ciphers - no authorization check needed

--- a/docs/architecture/deep-dives/authorization.md
+++ b/docs/architecture/deep-dives/authorization.md
@@ -73,7 +73,7 @@ To check whether the user has permissions to perform an action:
 var authorizationResult = await _authorizationService.AuthorizeAsync(User, resource, operation);
 if (!authorizationResult.Succeeded)
 {
-  throw new NotFoundError();
+  throw new NotFoundException();
 }
 ```
 
@@ -86,7 +86,7 @@ var cipher = cipherRequestModel.ToCipher();
 var authorizationResult = await _authorizationService.AuthorizeAsync(User, cipher, CipherOperations.Create);
 if (!authorizationResult.Succeeded)
 {
-  throw new NotFoundError();
+  throw new NotFoundException();
 }
 
 await _cipherRepository.Create(cipher);
@@ -101,7 +101,7 @@ var cipher = _cipherRepository.GetByIdAsync(id);
 var authorizationResult = await _authorizationService.AuthorizeAsync(User, cipher, CipherOperations.Read);
 if (!authorizationResult.Succeeded)
 {
-  throw new NotFoundError();
+  throw new NotFoundException();
 }
 
 return new CipherResponseModel(cipher);
@@ -116,7 +116,7 @@ var cipher = _cipherRepository.GetByIdAsync(id);
 var authorizationResult = await _authorizationService.AuthorizeAsync(User, cipher, CipherOperations.Update);
 if (!authorizationResult.Succeeded)
 {
-  throw new NotFoundError();
+  throw new NotFoundException();
 }
 
 // Only update the cipher after the authorization check has passed
@@ -140,7 +140,7 @@ var cipher = _cipherRepository.GetByIdAsync(id);
 var authorizationResult = await _authorizationService.AuthorizeAsync(User, cipher, CipherOperations.Delete);
 if (!authorizationResult.Succeeded)
 {
-  throw new NotFoundError();
+  throw new NotFoundException();
 }
 
 await _cipherRepository.DeleteAsync(cipher);
@@ -159,7 +159,7 @@ defined for this combination of resource and operation.
 var authorizationResult = await _authorizationService.AuthorizeAsync(User, new OrganizationResource(orgId), CipherOperations.ReadAllForOrganization);
 if (!authorizationResult.Succeeded)
 {
-  throw new NotFoundError();
+  throw new NotFoundException();
 }
 
 var result = await _cipherRepository.ReadManyByOrganizationId(orgId);


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
N/A

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Some follow-up changes to the authorization deep dive based on some recent discussions and experience.

The **main change** is to state that `AuthorizationService` should be called from the controller, rather than in the core layer (the query/command class). There are several reasons for this:
1. I still think that authz is fundamentally an api layer concern, mixing it in with business logic in the core layer makes everything more complex. It's useful to think of these separately.
2. Putting it in the command/query limits their re-use. Some queries may be used internally to check state, and are not returned out to the user. Some commands are used as side-effects with fixed argument values that need to be executed for all users, or may be executed by a job that is not tied to a user. Baking authorization into the main command/query logic really confuses things here.
3. It's awkward to inject the `ClaimsPrincipal` into the core layer. On the controller it's always available as `User`.
4. It's more obvious and easier to audit if there's a call in the controller before we enter the core layer.
5. We've already done this and it's been working well.

I have additional ideas around how to handle commands with complex authorization requirements, however I'd rather this guide follow our practice rather than vice versa. I don't want to overspecify here and keep having to amend it. We'll continue to iterate on it.

Other minor changes:
1. Refer to the `Bit.Core.Exceptions.NotFoundException` rather than `NotFoundError` (typo)
2. Don't refer to `AuthorizeOrThrowAsync`. I never added this overload and in retrospect I think it obscures things.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
