### PR TITLE
Add server setup for GitHub Packages

### DIFF
--- a/docs/getting-started/server/advanced-setup.md
+++ b/docs/getting-started/server/advanced-setup.md
@@ -192,9 +192,9 @@ services).
    - **Api** - `http://localhost:4100`
    - **Identity** - `http://localhost:33756`
 
-> If you need to add additional services (besides Api and Identity), add them to the
-> `dev/reverse-proxy.conf` and make sure the necessary ports are exposed in the
-> `dev/docker-compose.yml` file for the `reverse-proxy` container.
+If you need to add additional services (besides Api and Identity), add them to the
+`dev/reverse-proxy.conf` and make sure the necessary ports are exposed in the
+`dev/docker-compose.yml` file for the `reverse-proxy` container.
 
 ## NuGet with GitHub Packages
 

--- a/docs/getting-started/server/advanced-setup.md
+++ b/docs/getting-started/server/advanced-setup.md
@@ -82,12 +82,12 @@ File uploads are stored using one of two methods.
   }
   ```
 
-  :::note
+:::note
 
-  To properly test uploading and downloading files using direct upload, you need to set up a local
-  file server. Please add instructions here if you do this :)
+To properly test uploading and downloading files using direct upload, you need to set up a local
+file server.
 
-  :::
+:::
 
 ## PayPal
 

--- a/docs/getting-started/server/advanced-setup.md
+++ b/docs/getting-started/server/advanced-setup.md
@@ -216,5 +216,8 @@ along with pasting the value and pressing Enter. Next, run:
 dotnet nuget add source --username bitwarden --password $GITHUB_PAT --store-password-in-clear-text --name github --configfile ~/.nuget/NuGet/NuGet.Config "https://nuget.pkg.github.com/bitwarden/index.json"
 ```
 
-which will set up the necessary global source and credentials. Any NuGet restores will now also
+that will set up the necessary global source and credentials. Any NuGet restores will now also
 utilize our GitHub Packages setup for NuGet.
+
+Full releases of shared libraries will go to our
+[NuGet.org presence](https://www.nuget.org/profiles/Bitwarden).

--- a/docs/getting-started/server/advanced-setup.md
+++ b/docs/getting-started/server/advanced-setup.md
@@ -195,3 +195,26 @@ services).
 > If you need to add additional services (besides Api and Identity), add them to the
 > `dev/reverse-proxy.conf` and make sure the necessary ports are exposed in the
 > `dev/docker-compose.yml` file for the `reverse-proxy` container.
+
+## NuGet with GitHub Packages
+
+Server-side projects and solutions may use
+[Bitwarden-shared .NET extension libraries hosted on GitHub Packages](https://github.com/orgs/bitwarden/packages?repo_name=dotnet-extensions)
+and _prerelease_ packages offered via GitHub Packages require authentication for access.
+
+First, [generate](https://github.com/settings/tokens/new) a GitHub personal access token (classic)
+with the `packages:read` scope only. You can set an expiration date but it may be easier to leave it
+without one considering the scope. Copy the token value and run:
+
+```bash
+IFS= read -rs GITHUB_PAT < /dev/tty
+```
+
+along with pasting the value and pressing Enter. Next, run:
+
+```bash
+dotnet nuget add source --username bitwarden --password $GITHUB_PAT --store-password-in-clear-text --name github --configfile ~/.nuget/NuGet/NuGet.Config "https://nuget.pkg.github.com/bitwarden/index.json"
+```
+
+which will set up the necessary global source and credentials. Any NuGet restores will now also
+utilize our GitHub Packages setup for NuGet.

--- a/docs/getting-started/server/advanced-setup.md
+++ b/docs/getting-started/server/advanced-setup.md
@@ -199,8 +199,10 @@ If you need to add additional services (besides Api and Identity), add them to t
 ## NuGet with GitHub Packages
 
 Server-side projects and solutions may use
-[Bitwarden-shared .NET extension libraries hosted on GitHub Packages](https://github.com/orgs/bitwarden/packages?repo_name=dotnet-extensions)
-and _prerelease_ packages offered via GitHub Packages require authentication for access.
+[Bitwarden-shared .NET extension libraries](https://github.com/orgs/bitwarden/packages?repo_name=dotnet-extensions)
+and _prerelease_ packages offered via
+[GitHub Packages](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-nuget-registry)
+require authentication for access.
 
 First, [generate](https://github.com/settings/tokens/new) a GitHub personal access token (classic)
 with the `packages:read` scope only. You can set an expiration date but it may be easier to leave it

--- a/docs/getting-started/server/guide.md
+++ b/docs/getting-started/server/guide.md
@@ -294,6 +294,29 @@ attempting to "Build and Run the Server".
 
 </Bitwarden>
 
+## Configure NuGet with GitHub Packages
+
+Server-side projects and solutions may use
+[Bitwarden-shared .NET extension libraries hosted on GitHub Packages](https://github.com/orgs/bitwarden/packages?repo_name=dotnet-extensions)
+and these packages require authentication for access.
+
+First, [generate](https://github.com/settings/tokens/new) a GitHub personal access token (classic)
+with the `packages:read` scope only. You can set an expiration date but it may be easier to leave it
+without one considering the scope. Copy the token value and run:
+
+```bash
+IFS= read -rs GITHUB_PAT < /dev/tty
+```
+
+along with pasting the value and pressing Enter. Next, run:
+
+```bash
+dotnet nuget add source --username bitwarden --password $GITHUB_PAT --store-password-in-clear-text --name github --configfile ~/.nuget/NuGet/NuGet.Config "https://nuget.pkg.github.com/bitwarden/index.json"
+```
+
+which will set up the necessary global source and credentials. Any NuGet restores will now also
+utilize our NuGet GitHub Packages.
+
 ## Build and Run the Server
 
 You are now ready to build and run your development server.

--- a/docs/getting-started/server/guide.md
+++ b/docs/getting-started/server/guide.md
@@ -294,29 +294,6 @@ attempting to "Build and Run the Server".
 
 </Bitwarden>
 
-## Configure NuGet with GitHub Packages
-
-Server-side projects and solutions may use
-[Bitwarden-shared .NET extension libraries hosted on GitHub Packages](https://github.com/orgs/bitwarden/packages?repo_name=dotnet-extensions)
-and these packages require authentication for access.
-
-First, [generate](https://github.com/settings/tokens/new) a GitHub personal access token (classic)
-with the `packages:read` scope only. You can set an expiration date but it may be easier to leave it
-without one considering the scope. Copy the token value and run:
-
-```bash
-IFS= read -rs GITHUB_PAT < /dev/tty
-```
-
-along with pasting the value and pressing Enter. Next, run:
-
-```bash
-dotnet nuget add source --username bitwarden --password $GITHUB_PAT --store-password-in-clear-text --name github --configfile ~/.nuget/NuGet/NuGet.Config "https://nuget.pkg.github.com/bitwarden/index.json"
-```
-
-which will set up the necessary global source and credentials. Any NuGet restores will now also
-utilize our NuGet GitHub Packages.
-
 ## Build and Run the Server
 
 You are now ready to build and run your development server.


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-6950

## 📔 Objective

Adds documentation on how to set up GitHub Packages to enable restores of our new NuGet offerings there.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
