### PR TITLE
Update path to sdk-internal

### DIFF
--- a/docs/getting-started/sdk/index.md
+++ b/docs/getting-started/sdk/index.md
@@ -62,7 +62,7 @@ The web clients uses NPM to install the SDK as a dependency. NPM offers a dedica
 [`link`][npm-link] which can be used to temporarily replace the packages with a local version.
 
 ```bash
-npm link ../sdk/languages/sdk-internal
+npm link ../sdk/languages/js/sdk-internal
 ```
 
 :::warning


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

This was incorrectly set to `languages/sdk-internal` instead of `languages/js/sdk-internal`

You can check the correct path in the SDK repo: https://github.com/bitwarden/sdk/tree/main/languages/js/sdk-internal

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
