### PR TITLE
Add `readOnlyConnectionString`

### DIFF
--- a/docs/getting-started/server/database/ef/index.mdx
+++ b/docs/getting-started/server/database/ef/index.mdx
@@ -105,9 +105,6 @@ sure you update the existing values instead of creating new ones
 ```json
 "globalSettings:databaseProvider": "postgres",
 "globalSettings:postgreSql:connectionString": "Host=localhost;Username=postgres;Password=example;Database=vault_dev;Include Error Detail=true",
-
-// optional, falls back to the above connection string if not set
-"globalSettings:postgreSql:readOnlyConnectionString": "Host=localhost;Username=postgres;Password=example;Database=vault_dev;Include Error Detail=true",
 ```
 
 </TabItem>
@@ -119,9 +116,6 @@ sure you update the existing values instead of creating new ones
 ```json
 "globalSettings:databaseProvider": "mysql",
 "globalSettings:mySql:connectionString": "server=localhost;uid=root;pwd=example;database=vault_dev",
-
-// optional, falls back to the above connection string if not set
-"globalSettings:mySql:readOnlyConnectionString": "server=localhost;uid=root;pwd=example;database=vault_dev",
 ```
 
 </TabItem>
@@ -133,9 +127,6 @@ Source path. Use the file location selected in [Database Setup](#database-setup)
 ```json
 "globalSettings:databaseProvider": "sqlite",
 "globalSettings:sqlite:connectionString": "Data Source=/path/to/your/server/repo/dev/db/bitwarden.db",
-
-// optional, falls back to the above connection string if not set
-"globalSettings:sqlite:readOnlyConnectionString": "Data Source=/path/to/your/server/repo/dev/db/bitwarden.db",
 ```
 
 </TabItem>

--- a/docs/getting-started/server/database/ef/index.mdx
+++ b/docs/getting-started/server/database/ef/index.mdx
@@ -105,6 +105,9 @@ sure you update the existing values instead of creating new ones
 ```json
 "globalSettings:databaseProvider": "postgres",
 "globalSettings:postgreSql:connectionString": "Host=localhost;Username=postgres;Password=example;Database=vault_dev;Include Error Detail=true",
+
+// optional, falls back to the above connection string if not set
+"globalSettings:postgreSql:readOnlyConnectionString": "Host=localhost;Username=postgres;Password=example;Database=vault_dev;Include Error Detail=true",
 ```
 
 </TabItem>
@@ -116,6 +119,9 @@ sure you update the existing values instead of creating new ones
 ```json
 "globalSettings:databaseProvider": "mysql",
 "globalSettings:mySql:connectionString": "server=localhost;uid=root;pwd=example;database=vault_dev",
+
+// optional, falls back to the above connection string if not set
+"globalSettings:mySql:readOnlyConnectionString": "server=localhost;uid=root;pwd=example;database=vault_dev",
 ```
 
 </TabItem>
@@ -127,6 +133,9 @@ Source path. Use the file location selected in [Database Setup](#database-setup)
 ```json
 "globalSettings:databaseProvider": "sqlite",
 "globalSettings:sqlite:connectionString": "Data Source=/path/to/your/server/repo/dev/db/bitwarden.db",
+
+// optional, falls back to the above connection string if not set
+"globalSettings:sqlite:readOnlyConnectionString": "Data Source=/path/to/your/server/repo/dev/db/bitwarden.db",
 ```
 
 </TabItem>

--- a/docs/getting-started/server/database/mssql/index.md
+++ b/docs/getting-started/server/database/mssql/index.md
@@ -24,3 +24,24 @@ of your database.
 
 The process for modifying the database is described in
 [Migrations](./../../../../contributing/database-migrations/).
+
+## Running self-hosted locally
+
+### SQL Server (Dapper)
+
+To set up a self-hosted instance locally, you should follow the instructions
+[here](../self-hosted/). Assuming you've defined your user secrets as described in the
+[User Secrets](../../user-secrets/) documentation, you'll find that if you don't define the
+`readOnlyConnectionString` override as shown below, your self-hosted instance will fall back to use
+the regular/default connection string. This can result in unexpected behavior as your self-hosted
+instance will be reading from the wrong database.
+
+You can simply copy whatever value you have for `connectionString` and copy it to
+`readOnlyConnectionString` in your secrets.json file.
+
+```json
+{
+  "dev:selfHostOverride:globalSettings:sqlServer:connectionString": "Server=localhost;Database=vault_dev_self_host;User Id=sa;Password=your_password_here",
+  "dev:selfHostOverride:globalSettings:sqlServer:readOnlyConnectionString": "Server=localhost;Database=vault_dev_self_host;User Id=sa;Password=your_password_here"
+}
+```


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

The `readOnlyConnectionString` isn't documented anywhere publicly, and is relevant when developing locally for self-hosting.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
