### PR TITLE
replace GPG signing recommendation with SSH

### DIFF
--- a/docs/contributing/commit-signing.mdx
+++ b/docs/contributing/commit-signing.mdx
@@ -26,8 +26,8 @@ Github supports commit signing with GPG, SSH and S/MIME.
 :::tip
 
 If you're unsure what to use, we recommend SSH. Create a new commit signing key instead of reusing
-your Github authentication key. Remember to protect the key with a
-[strong passphrase or password](password-generation).
+your Github authentication key. Remember to protect the key with a [strong passphrase or
+password][password-generation].
 
 ```bash
 EMAIL=your.commit.email@example.com

--- a/docs/contributing/commit-signing.mdx
+++ b/docs/contributing/commit-signing.mdx
@@ -29,7 +29,9 @@ If you're unsure what to use, we recommend you create a commit signing key using
 protect the key with a [strong passphrase or password][password-generation].
 
 ```bash
-ssh-keygen -f ~/.ssh/bw-signing -C "$(git config --get user.email)" -t ed25519
+# path to save your private signing key
+KEY_FILE=~/.ssh/bw-signing
+ssh-keygen -f $KEY_FILE -C "$(git config --global --get user.email)" -t ed25519
 ```
 
 :::
@@ -40,7 +42,7 @@ ssh-keygen -f ~/.ssh/bw-signing -C "$(git config --get user.email)" -t ed25519
 
    ```bash
    git config --global gpg.format=ssh
-   git config --global user.signingkey=~/.ssh/bw-signing.pub
+   git config --global user.signingkey="${KEY_FILE}.pub"
    ```
 
 2. Follow the [Github documentation][github-verification] to configure commit signing

--- a/docs/contributing/commit-signing.mdx
+++ b/docs/contributing/commit-signing.mdx
@@ -22,33 +22,31 @@ their commits.
 ## Setting up commit signing
 
 Github supports commit signing with GPG, SSH and S/MIME. If you're unsure what to use, we recommend
-GPG.
+SSH.
 
-1.  Install GnuPG:
+1.  Follow the [Github documentation][github-verification] to configure commit signing
 
-  <Tabs groupId="os">
+2.  Configure your preferred git tool below
 
-    <TabItem value="mac" label="macOS">
-
-    ```bash
-    brew install gnupg
-    echo "export GPG_TTY=$(tty)" >> ~/.zshrc
-    ```
-
-    Restart your open terminal for this to take effect
-
-    </TabItem>
-
-  </Tabs>
-
-2.  Follow the [Github documentation][github-verification] to configure commit signing
-
-3.  Configure your preferred git tool below
-
-4.  Push a test commit to Github and ensure that the "Verified" badge appears next to the commit
+3.  Push a test commit to Github and ensure that the "Verified" badge appears next to the commit
     description:
 
     ![Image showing the Verified badge in Github](./commit-signing.png)
+
+:::tip
+
+We recommend you create a new commit signing key instead of reusing your Github authentication key,
+and that you protect the key with a strong passphrase or password.
+
+```bash
+EMAIL=your.commit.email@example.com
+ssh-keygen -f ~/.ssh/bw-signing -C "$EMAIL" -t ed25519
+git.config --global user.email "$EMAIL"
+git config --global gpg.format=ssh
+git config --global user.signingkey=~/.ssh/bw-signing.pub
+```
+
+(Remove the `--global` flags to only apply this setting to the current repository) :::
 
 ### Command Line
 
@@ -58,10 +56,11 @@ GPG.
   git commit -S
   ```
 
-- To avoid using the `-S` flag every time, you can sign all commits by default:
+- To avoid using the `-S` flag every time, you can sign all commits and tags by default:
 
   ```bash
   git config --global commit.gpgSign true
+  git config --global tag.gpgSign true
   ```
 
   (Remove the `--global` flag to only apply this setting to the current repository)

--- a/docs/contributing/commit-signing.mdx
+++ b/docs/contributing/commit-signing.mdx
@@ -43,8 +43,6 @@ ssh-keygen -f ~/.ssh/bw-signing -C "$(git config --get user.email)" -t ed25519
    git config --global user.signingkey=~/.ssh/bw-signing.pub
    ```
 
-   (Remove the `--global` flag to only apply this setting to the current repository.)
-
 2. Follow the [Github documentation][github-verification] to configure commit signing
 
 3. Configure your preferred git tool below
@@ -68,8 +66,6 @@ ssh-keygen -f ~/.ssh/bw-signing -C "$(git config --get user.email)" -t ed25519
   git config --global commit.gpgSign true
   git config --global tag.gpgSign true
   ```
-
-  (Remove the `--global` flag to only apply this setting to the current repository.)
 
 ### Visual Studio Code
 

--- a/docs/contributing/commit-signing.mdx
+++ b/docs/contributing/commit-signing.mdx
@@ -21,22 +21,13 @@ their commits.
 
 ## Setting up commit signing
 
-Github supports commit signing with GPG, SSH and S/MIME. If you're unsure what to use, we recommend
-SSH.
-
-1.  Follow the [Github documentation][github-verification] to configure commit signing
-
-2.  Configure your preferred git tool below
-
-3.  Push a test commit to Github and ensure that the "Verified" badge appears next to the commit
-    description:
-
-    ![Image showing the Verified badge in Github](./commit-signing.png)
+Github supports commit signing with GPG, SSH and S/MIME.
 
 :::tip
 
-We recommend you create a new commit signing key instead of reusing your Github authentication key,
-and that you protect the key with a strong passphrase or password.
+If you're unsure what to use, we recommend SSH. Create a new commit signing key instead of reusing
+your Github authentication key. Remember to protect the key with a
+[strong passphrase or password](password-generation).
 
 ```bash
 EMAIL=your.commit.email@example.com
@@ -49,6 +40,15 @@ git config --global user.signingkey=~/.ssh/bw-signing.pub
 (Remove the `--global` flags to only apply this setting to the current repository)
 
 :::
+
+1.  Follow the [Github documentation][github-verification] to configure commit signing
+
+2.  Configure your preferred git tool below
+
+3.  Push a test commit to Github and ensure that the "Verified" badge appears next to the commit
+    description:
+
+    ![Image showing the Verified badge in Github](./commit-signing.png)
 
 ### Command Line
 
@@ -103,5 +103,6 @@ Refer to
   [this troubleshooting document](https://gist.github.com/paolocarrasco/18ca8fe6e63490ae1be23e84a7039374)
   for more help with this error
 
+[password-generation]: https://bitwarden.com/help/generator/#password-types
 [github-verification]:
   https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification

--- a/docs/contributing/commit-signing.mdx
+++ b/docs/contributing/commit-signing.mdx
@@ -43,6 +43,8 @@ ssh-keygen -f ~/.ssh/bw-signing -C "$(git config --get user.email)" -t ed25519
    git config --global user.signingkey=~/.ssh/bw-signing.pub
    ```
 
+   (Remove the `--global` flag to only apply this setting to the current repository.)
+
 2. Follow the [Github documentation][github-verification] to configure commit signing
 
 3. Configure your preferred git tool below
@@ -67,7 +69,7 @@ ssh-keygen -f ~/.ssh/bw-signing -C "$(git config --get user.email)" -t ed25519
   git config --global tag.gpgSign true
   ```
 
-  (Remove the `--global` flag to only apply this setting to the current repository)
+  (Remove the `--global` flag to only apply this setting to the current repository.)
 
 ### Visual Studio Code
 

--- a/docs/contributing/commit-signing.mdx
+++ b/docs/contributing/commit-signing.mdx
@@ -25,30 +25,32 @@ Github supports commit signing with GPG, SSH and S/MIME.
 
 :::tip
 
-If you're unsure what to use, we recommend SSH. Create a new commit signing key instead of reusing
-your Github authentication key. Remember to protect the key with a [strong passphrase or
-password][password-generation].
+If you're unsure what to use, we recommend you create a commit signing key using SSH. Remember to
+protect the key with a [strong passphrase or password][password-generation].
 
 ```bash
-EMAIL=your.commit.email@example.com
-ssh-keygen -f ~/.ssh/bw-signing -C "$EMAIL" -t ed25519
-git.config --global user.email "$EMAIL"
-git config --global gpg.format=ssh
-git config --global user.signingkey=~/.ssh/bw-signing.pub
+ssh-keygen -f ~/.ssh/bw-signing -C "$(git config --get user.email)" -t ed25519
 ```
-
-(Remove the `--global` flags to only apply this setting to the current repository)
 
 :::
 
-1.  Follow the [Github documentation][github-verification] to configure commit signing
+### Configuration
 
-2.  Configure your preferred git tool below
+1. Configure git to sign using SSH.
 
-3.  Push a test commit to Github and ensure that the "Verified" badge appears next to the commit
-    description:
+   ```bash
+   git config --global gpg.format=ssh
+   git config --global user.signingkey=~/.ssh/bw-signing.pub
+   ```
 
-    ![Image showing the Verified badge in Github](./commit-signing.png)
+2. Follow the [Github documentation][github-verification] to configure commit signing
+
+3. Configure your preferred git tool below
+
+4. Push a test commit to Github and ensure that the "Verified" badge appears next to the commit
+   description:
+
+   ![Image showing the Verified badge in Github](./commit-signing.png)
 
 ### Command Line
 

--- a/docs/contributing/commit-signing.mdx
+++ b/docs/contributing/commit-signing.mdx
@@ -46,7 +46,9 @@ git config --global gpg.format=ssh
 git config --global user.signingkey=~/.ssh/bw-signing.pub
 ```
 
-(Remove the `--global` flags to only apply this setting to the current repository) :::
+(Remove the `--global` flags to only apply this setting to the current repository)
+
+:::
 
 ### Command Line
 


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Now that GitHub's SSH key signing support has matured, recommend using an SSH key for commit verification.

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
