### PR TITLE
[PM-17562] Add documentation for the initial Distributed Events POC

### DIFF
--- a/docs/getting-started/server/events.md
+++ b/docs/getting-started/server/events.md
@@ -125,19 +125,23 @@ To enable the new RabbitMQ-based event stream, take the following steps:
 1.  Add the following to your `secrets.json` file, changing the defaults to match your `.env` file:
 
     ```json
-        "rabbitMq": {
-          "hostName": "localhost",
-          "username": "bitwarden",
-          "password": "SET_A_PASSWORD_HERE_123",
-          "exchangeName": "events-exchange"
-        },
+    "eventLogging": {
+      "rabbitMq": {
+        "hostName": "localhost",
+        "username": "bitwarden",
+        "password": "SET_A_PASSWORD_HERE_123",
+        "exchangeName": "events-exchange",
+        "eventRepositoryQueueName": "events-write-queue",
+      }
+    }
     ```
 
-2.  (optional) To use the `RabbitMqEventHttpPostListener`, specify a destination URL that will
-    receive the POST.
+2.  (optional) To use the RabbitMqEventHttpPostListener, specify a queue name and destination URL
+    that will receive the POST inside the RabbitMq object:
 
     ```json
-        "rabbitMqHttpPostUrl": "<HTTP POST URL>",
+        "httpPostQueueName": "events-httpPost-queue",
+        "httpPostUrl": "<HTTP POST URL>",
     ```
 
     - Tip: [RequestBin](http://requestbin.com/) provides an easy to set up server that will receive

--- a/docs/getting-started/server/events.md
+++ b/docs/getting-started/server/events.md
@@ -55,7 +55,7 @@ To use database storage for events:
 2. Start the Events project using `dotnet run` or your IDE (note: EventsProcessor is not required
    for self-hosted)
 
-## Distributed Events (optional)
+## Distributed events (optional)
 
 There is a new system which will add support for distributing events via an AMQP messaging system.
 In the future this will enable new integrations by allowing for a means to subscribe to events via
@@ -72,25 +72,34 @@ To illustrate this, there is also a `RabbitMqEventHttpPostListener` which subscr
 events exchange and `POST`s each event to a configurable URL. This is meant to be a simple, concrete
 example of how multiple integrations are enabled by moving to distributed events.
 
-### Without RabbitMQ configured
+```kroki type=mermaid
+graph TD
+	  subgraph Optional RabbitMQ implementation
+        B1[EventService]
+        B2[RabbitMQEventWriteService]
+        B3[RabbitMQ exchange]
+        B4[RabbitMqEventRepositoryListener]
+        B5[RabbitMqEventHttpPostListener]
+        B6[Events Database Table]
+        B7[HTTP Server]
 
-If RabbitMQ is not configured the order of operations is:
+        B1 -->|IEventWriteService| B2 --> B3
+        B3--> B4 --> B6
+        B3--> B5
+        B5 -->|HTTP POST| B7
+    end
 
-1. `EventService`
-2. `RepositoryEventWriteService`
-3. `Events Database Table`
+    subgraph Existing self-hosted implementation
+        A1[EventService]
+        A2[RepositoryEventWriteService]
+        A3[Events Database Table]
 
-### With RabbitMQ configured
+        A1 -->|IEventWriteService| A2 --> A3
 
-With RabbitMQ is configured the outcome is the same, but there are more operations:
+end
 
-1. `EventService`
-2. `RabbitMqEventWriteService`
-3. `RabbitMQ Exhange`
-   1. `RabbitMqEventRepositoryListener`
-      1. `Events Database Table`
-   2. `RabbitMqEventHttpPostListener` (if configured)
-      1. `POST` to configured URL
+
+```
 
 To enable the new RabbitMQ-based event stream, take the following steps:
 

--- a/docs/getting-started/server/events.md
+++ b/docs/getting-started/server/events.md
@@ -57,20 +57,19 @@ To use database storage for events:
 
 ## Distributed events (optional)
 
-There is a new system which will add support for distributing events via an AMQP messaging system.
-In the future this will enable new integrations by allowing for a means to subscribe to events via
-messaging stream.
+Events can be distributed via an AMQP messaging system. This messaging system enables new
+integrations to subscribe to the events.
 
-As an initial proof of concept, there is an optional RabbitMQ implementation that refactors the way
-events are handled when running locally or self-hosted. Instead of writing directly to the `Events`
-table via the `EventsRepository`, it will broadcast each event via a RabbitMQ exchange. A new
-`RabbitMqEventRepositoryListener` then subscribes to the RabbitMQ exchange and writes to the
-`Events` table via the `EventsRepository`. The end result is the same (events are stored in the
-database), but this allows for other integrations to subscribe.
+The RabbitMQ implementation adds a step that refactors the way events are handled when running
+locally or self-hosted. Instead of writing directly to the `Events` table via the
+`EventsRepository`, each event is broadcast to a RabbitMQ exchange. A new
+`RabbitMqEventRepositoryListener` subscribes to the RabbitMQ exchange and writes to the `Events`
+table via the `EventsRepository`. The end result is the same (events are stored in the database),
+but the addition of the RabbitMQ exchange allows for other integrations to subscribe.
 
-To illustrate this, there is also a `RabbitMqEventHttpPostListener` which subscribes to the RabbitMQ
-events exchange and `POST`s each event to a configurable URL. This is meant to be a simple, concrete
-example of how multiple integrations are enabled by moving to distributed events.
+To illustrate the ability to fan-out events, `RabbitMqEventHttpPostListener` subscribes to the
+RabbitMQ events exchange and `POST`s each event to a configurable URL. This is meant to be a simple,
+concrete example of how multiple integrations are enabled by moving to distributed events.
 
 ```kroki type=mermaid
 graph TD
@@ -97,11 +96,7 @@ graph TD
         A1 -->|IEventWriteService| A2 --> A3
 
 end
-
-
 ```
-
-To enable the new RabbitMQ-based event stream, take the following steps:
 
 ### Running the RabbitMQ container
 
@@ -114,10 +109,11 @@ To enable the new RabbitMQ-based event stream, take the following steps:
     docker compose --profile rabbitmq up -d
     ```
 
-3.  This will run the RabbitMQ container with your username and password on localhost with the
-    standard ports
+    - The compose configuration uses the username and password from the `env` file.
+    - It is configured to run on localhost with RabbitMQ's standard ports, but this can be
+      customized in the docker configuration.
 
-4.  To verify this is running, open `http://localhost:15672` in a browser and login with the
+3.  To verify this is running, open `http://localhost:15672` in a browser and login with the
     username and password in your `.env` file.
 
 ### Configuring the server to use RabbitMQ for events
@@ -157,4 +153,4 @@ To enable the new RabbitMQ-based event stream, take the following steps:
 
 With these changes in place, you should see the database events written as before, but you'll also
 see in the RabbitMQ management interface that the messages are flowing through the configured
-exchange.
+exchange/queues.

--- a/docs/getting-started/server/events.md
+++ b/docs/getting-started/server/events.md
@@ -74,7 +74,7 @@ example of how multiple integrations are enabled by moving to distributed events
 
 ```kroki type=mermaid
 graph TD
-	  subgraph Optional RabbitMQ implementation
+	  subgraph With RabbitMQ
         B1[EventService]
         B2[RabbitMQEventWriteService]
         B3[RabbitMQ exchange]
@@ -89,7 +89,7 @@ graph TD
         B5 -->|HTTP POST| B7
     end
 
-    subgraph Existing self-hosted implementation
+    subgraph Without RabbitMQ
         A1[EventService]
         A2[RepositoryEventWriteService]
         A3[Events Database Table]

--- a/docs/getting-started/server/events.md
+++ b/docs/getting-started/server/events.md
@@ -111,7 +111,7 @@ end
 
     - The compose configuration uses the username and password from the `env` file.
     - It is configured to run on localhost with RabbitMQ's standard ports, but this can be
-      customized in the docker configuration.
+      customized in the Docker configuration.
 
 3.  To verify this is running, open `http://localhost:15672` in a browser and login with the
     username and password in your `.env` file.
@@ -143,7 +143,7 @@ end
     - Tip: [RequestBin](http://requestbin.com/) provides an easy to set up server that will receive
       these requests and let you inspect them.
 
-3.  Re-run the powershell script to add these secrets to each Bitwarden project:
+3.  Re-run the PowerShell script to add these secrets to each Bitwarden project:
 
     ```bash
     pwsh setup_secrets.ps1


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17562](https://bitwarden.atlassian.net/browse/PM-17562)

## 📔 Objective

Corresponding server PR: https://github.com/bitwarden/server/pull/5323

The above PR adds support for an initial POC of a new feature in the Events pipeline. This PR adds some documentation about how to opt-in and setup those distributed events locally.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17562]: https://bitwarden.atlassian.net/browse/PM-17562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ