### PR TITLE
Use maximum compatible `git config` syntax.

### DIFF
--- a/docs/contributing/commit-signing.mdx
+++ b/docs/contributing/commit-signing.mdx
@@ -41,8 +41,8 @@ ssh-keygen -f $KEY_FILE -C "$(git config --global --get user.email)" -t ed25519
 1. Configure git to sign using SSH.
 
    ```bash
-   git config --global gpg.format=ssh
-   git config --global user.signingkey="${KEY_FILE}.pub"
+   git config --global gpg.format ssh
+   git config --global user.signingkey "${KEY_FILE}.pub"
    ```
 
 2. Follow the [Github documentation][github-verification] to configure commit signing


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Onboarding Feedback:

Not clear when `git config <name>=<value>` syntax would have been valid (a cursory look back to the earliest available official [`git config` docs](https://git-scm.com/docs/git-config/2.0.5) don't show it, but I may have missed something). 

`<name>=<value>` is valid syntax inside of a .gitconfig file however, but not in this command. 

As of 2.46.0, git config supports subcommands (i.e. `git config set --global <name> <value>`.

As of this writing, newly provisioned macbooks ship with git version 2.39.5 (Apple Git-154).

As an illustration, this supports neither the most recent subcommand syntax, nor the current documentation syntax:

```
git version 2.39.5 (Apple Git-154)
user@macbook % git config set butter.bread true
error: key does not contain a section: set
user@macbook % git config --global butter.bread=true
error: invalid key: butter.bread=true
```

If a contributor installs the most recent version of `git`, omitting a subcommand or flag is still valid, although considered a [deprecated mode](https://git-scm.com/docs/git-config#_deprecated_modes) in favor of subcommands.

```
git version 2.48.1
user@macbook % git config --global butter.bagel true # success
user@macbook % git config set --global butter.bagel true # preferred
```

This commit favors the deprecated but backward compatible syntax—open to alternative ideas.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
