### PR TITLE
Remove link indicating EOL for Visual Studio for Mac

### DIFF
--- a/docs/getting-started/tools/index.md
+++ b/docs/getting-started/tools/index.md
@@ -20,6 +20,8 @@ environment.
 
 - [Visual Studio Code](https://code.visualstudio.com/) - used for all Typescript projects.
   Suboptimal for C#. Be sure to install [extensions](#visual-studio-code-extensions)
+- [JetBrains Rider](https://www.jetbrains.com/rider/download/) - fully featured IDE for C#, .NET &
+  more.
 - [Xcode](https://developer.apple.com/xcode/) - required for iOS Mobile development and Safari web
   extension
 
@@ -109,8 +111,6 @@ recommended ones include the following:
 
 The following tools may be useful depending on your preferences or what you’re developing.
 
-- [JetBrains Rider](https://www.jetbrains.com/rider/) ($) - an alternative to Visual Studio and/or
-  Visual Studio Code
 - [Microsoft Azure Storage Explorer](https://azure.microsoft.com/en-us/features/storage-explorer/) -
   for connecting to or working with local Azure table storage and queues
 - [Parallels](https://www.parallels.com/) - For running Windows VMs

--- a/docs/getting-started/tools/index.md
+++ b/docs/getting-started/tools/index.md
@@ -20,8 +20,6 @@ environment.
 
 - [Visual Studio Code](https://code.visualstudio.com/) - used for all Typescript projects.
   Suboptimal for C#. Be sure to install [extensions](#visual-studio-code-extensions)
-- [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/) - Pretty good at C# (Server
-  and Mobile)
 - [Xcode](https://developer.apple.com/xcode/) - required for iOS Mobile development and Safari web
   extension
 

--- a/docs/getting-started/tools/index.md
+++ b/docs/getting-started/tools/index.md
@@ -21,7 +21,7 @@ environment.
 - [Visual Studio Code](https://code.visualstudio.com/) - used for all Typescript projects.
   Suboptimal for C#. Be sure to install [extensions](#visual-studio-code-extensions)
 - [JetBrains Rider](https://www.jetbrains.com/rider/download/) - fully featured IDE for C#, .NET &
-  more.
+  more. Bitwarden developers should contact IT for a license
 - [Xcode](https://developer.apple.com/xcode/) - required for iOS Mobile development and Safari web
   extension
 


### PR DESCRIPTION
## 📔 Objective

This may be more of a conversation prompt (I can demote back to draft PR), but following [the link](https://visualstudio.microsoft.com/vs/mac/) currently in the docs here indicates that Visual Studio for Mac is at EOL, and is no longer being supported and maintained as of August 2024, and therefore only downloadable to those with a pre-existing license.

I don't have C# IDE expertise but thought we could come up with an alternative experience here for new contributors. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
