### PR TITLE
add warning about splunk incompatabilty with v9.4 for apple silicon

### DIFF
--- a/docs/getting-started/business/splunk-app.md
+++ b/docs/getting-started/business/splunk-app.md
@@ -54,9 +54,13 @@ in Splunk.
    docker run --rm --platform linux/amd64 --name splunk -d -p 8001:8000 -p 8089:8089 -e SPLUNK_START_ARGS='--accept-license' -e SPLUNK_PASSWORD='password' splunk/splunk:9.3
    ```
 
-:::warning If you are using an Apple Silicon Mac, you must use up to version 9.3 of splunk. As of
-version 9.4, splunk depends on the use of the AVX instruction set for its KVStore, which is not
-supported by Apple Silicon. :::
+:::warning
+
+If you are using an Apple Silicon Mac, you must use up to version 9.3 of Splunk. As of version 9.4,
+Splunk depends on the use of the AVX instruction set for its KVStore, which is not supported by
+Apple Silicon.
+
+:::
 
 Please note this will set the admin password to `password`. This is for development purposes only.
 

--- a/docs/getting-started/business/splunk-app.md
+++ b/docs/getting-started/business/splunk-app.md
@@ -54,8 +54,11 @@ in Splunk.
    docker run --rm --platform linux/amd64 --name splunk -d -p 8001:8000 -p 8089:8089 -e SPLUNK_START_ARGS='--accept-license' -e SPLUNK_PASSWORD='password' splunk/splunk:9.3
    ```
 
-   Please note this will set the admin password to `password`. This is for development purposes
-   only.
+:::warning If you are using an Apple Silicon Mac, you must use up to version 9.3 of splunk. As of
+version 9.4, splunk depends on the use of the AVX instruction set for its KVStore, which is not
+supported by Apple Silicon. :::
+
+Please note this will set the admin password to `password`. This is for development purposes only.
 
 2. Confirm that Splunk is running by navigating to http://localhost:8001
 


### PR DESCRIPTION
## 🎟️ Tracking
N/A
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Adds a warning about Splunk v9.4 being incompatible with Apple Silicon. The root cause is dependent on the user’s cpu architecture (and their support for the AVX instruction set) for the new mongoDB 7.1 dependency in Splunk v9.4. ARM based processors (like Apple silicon) don’t support AVX and therefore, the KVstore (mongoDB) fails to initialize. This can be seen in the container’s shell by running ./splunk show kvstore-status and the resultant status being in a failed state before we ever run the deploy script. This was further confirmed by running the v9.4 container on a Linux x86 based system, which saw the KVStore initialize without issue.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
![Screenshot 2025-02-20 at 12 03 11 PM](https://github.com/user-attachments/assets/ce46d0b6-0c1b-49af-b8f2-40c6b0bccbcf)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
