### PR TITLE
Add Extension Persistence Deep Dive

### DIFF
--- a/docs/architecture/deep-dives/extension-persistence/index.md
+++ b/docs/architecture/deep-dives/extension-persistence/index.md
@@ -1,0 +1,108 @@
+# Extension Persistence
+
+By default, when the browser extension popup closes, the user's current view and any data that was
+entered is lost. This introduces friction in several workflows within our client, such as:
+
+- Performing actions that require email OTP entry, since the user must navigate from the popup to
+  get to their email inbox
+- Entering information to create a new vault item from a browser tab
+- And many more
+
+Previously, we have recommended that users "pop out" the extension into its own window to persist
+the extension context, but this introduces additional user actions and may leave the extension open
+(and unlocked) for longer than a user intends.
+
+In order to provide a better user experience, we have introduced two levels of persistence to the
+Bitwarden extension client:
+
+- We persist the route history, allowing us to re-open the last route when the popup re-opens, and
+- We offer a service for teams to use to persist component-specific form data or state to survive a
+  popup close/re-open cycle
+
+## Persistence lifetime
+
+Since we are persisting data, it is important that the lifetime of that data be well-understood and
+well-constrained. The cache of route history and form data is cleared when any of the following
+events occur:
+
+- The account is locked
+- The account is logged out
+- Account switching is used to switch the active account
+- The extension popup has been closed for 2 minutes
+
+## Types of persistence
+
+### Route history persistence
+
+Route history is persisted on the extension automatically, with no specific implementation required
+on any component.
+
+The `ViewCacheService` implementation ensures that the popup will open at the same route as was
+active when it closed, provided that none of the lifetime expiration events have occurred.
+
+### Form data persistence
+
+In order to persist data entered or state created within a component, so that a user's full
+in-progress state is restored when the popup re-opens, we provide a
+[`ViewCacheService`](https://github.com/bitwarden/clients/blob/main/libs/angular/src/platform/abstractions/view-cache.service.ts).
+
+The `ViewCacheService` can be used in your component and provides an interface for caching both
+individual state and `FormGroup`s.
+
+For individual data, use the `signal()` method to create a writeable
+[signal](https://angular.dev/guide/signals) wrapper around the desired state. The signal will emit
+when the value in the cache changes
+
+```typescript
+
+const mySignal = this.viewCacheService.signal({
+    key: "my-state-key"
+    initialValue: null
+});
+
+```
+
+Setting the value should be done through the signal's `set()` method:
+
+```typescript
+
+const mySignal = this.viewCacheService.signal({
+    key: "my-state-key"
+    initialValue: null
+});
+mySignal.set("value")
+
+```
+
+:::note Equality comparison
+
+By default, signals use `Object.is` to determine equality, and `set()` will only trigger updates if
+the updated value is not equal to the current signal state. See documentation
+[here](https://angular.dev/guide/signals#signal-equality-functions).
+
+:::
+
+For persisting form data, the `ViewCacheService` supplies a `formGroup()` method. Which manages the
+persistence of any entered form data to the cache and the initialization of the form from the cached
+data. You can supply the `FormGroup` in the `control` parameter of the method, and the
+`ViewCacheService` will:
+
+- Initialize the form the a cached value, if it exists
+- Save form value to cache when it changes
+- Mark the form dirty if the restored value is not `undefined`.
+
+```typescript
+this.loginDetailsForm = this.viewCacheService.formGroup({
+  key: "my-form",
+  control: this.formBuilder.group({
+    username: [""],
+    email: [""],
+  }),
+});
+```
+
+#### What about other clients?
+
+The `ViewCacheService` is designed to be injected into shared, client-agnostic components. A
+`NoopViewCacheService` is provided and injected for non-extension clients, preserving a single
+interface for your components.

--- a/docs/architecture/deep-dives/extension-persistence/index.md
+++ b/docs/architecture/deep-dives/extension-persistence/index.md
@@ -40,6 +40,9 @@ on any component.
 The `ViewCacheService` implementation ensures that the popup will open at the same route as was
 active when it closed, provided that none of the lifetime expiration events have occurred.
 
+:::tip Excluding a route If a particular route should be excluded from the history and not
+persisted, add `doNotSaveUrl: true` to the `data` property on the route. :::
+
 ### Form data persistence
 
 In order to persist data entered or state created within a component, so that a user's full

--- a/docs/architecture/deep-dives/extension-persistence/index.md
+++ b/docs/architecture/deep-dives/extension-persistence/index.md
@@ -96,11 +96,11 @@ the updated value is not equal to the current signal state. See documentation
 Putting this together, the most common implementation pattern would be:
 
 1. **Register the signal** using `ViewCacheService.signal()` on initialization of the component or
-   service responsible for the state being persisted
+   service responsible for the state being persisted.
 2. **Restore state from the signal:** If cached data exists, the signal will contain that data. The
    component or service should use this data to re-create the state from prior to the popup closing.
 3. **Set new state** in the cache when it changes. Ensure that any updates to the data are persisted
-   to the cache with `set()`, so that the cache reflects the latest state
+   to the cache with `set()`, so that the cache reflects the latest state.
 
 #### Caching form data
 

--- a/docs/architecture/deep-dives/extension-persistence/index.md
+++ b/docs/architecture/deep-dives/extension-persistence/index.md
@@ -100,7 +100,7 @@ Putting this together, the most common implementation pattern would be:
 2. **Restore state from the signal.** If cached data exists, the signal will contain that data. The
    component or service should use this data to re-create the state from prior to the popup closing.
 3. **Set new state** in the cache when it changes. Ensure that any updates to the data are persisted
-   to the cache with `set()`, so that the cache reflects the latest state`
+   to the cache with `set()`, so that the cache reflects the latest state
 
 #### Caching form data
 

--- a/docs/architecture/deep-dives/extension-persistence/index.md
+++ b/docs/architecture/deep-dives/extension-persistence/index.md
@@ -30,6 +30,9 @@ events occur:
 - Account switching is used to switch the active account
 - The extension popup has been closed for 2 minutes
 
+In addition, cached form data is cleared when a browser extension navigation event occurs (e.g.
+switching between tabs in the extension).
+
 ## Types of persistence
 
 ### Route history persistence
@@ -97,14 +100,12 @@ Putting this together, the most common implementation pattern would be:
 2. **Restore state from the signal.** If cached data exists, the signal will contain that data. The
    component or service should use this data to re-create the state from prior to the popup closing.
 3. **Set new state** in the cache when it changes. Ensure that any updates to the data are persisted
-   to the cache with `set()`, so that the cache reflects the latest state
+   to the cache with `set()`, so that the cache reflects the latest state`
 
 #### Caching form data
 
-For persisting form data, the `ViewCacheService` supplies a `formGroup()` method, which manages the
-persistence of any entered form data to the cache and the initialization of the form from the cached
-data. You can supply the `FormGroup` in the `control` parameter of the method, and the
-`ViewCacheService` will:
+`For persisting form data, the`ViewCacheService`supplies a`formGroup()`method, which manages the persistence of any entered form data to the cache and the initialization of the form from the cached data. You can supply the`FormGroup`in the`control`parameter of the method, and the`ViewCacheService`
+will:
 
 - Initialize the form the a cached value, if it exists
 - Save form value to cache when it changes

--- a/docs/architecture/deep-dives/extension-persistence/index.md
+++ b/docs/architecture/deep-dives/extension-persistence/index.md
@@ -104,7 +104,9 @@ Putting this together, the most common implementation pattern would be:
 
 #### Caching form data
 
-`For persisting form data, the`ViewCacheService`supplies a`formGroup()`method, which manages the persistence of any entered form data to the cache and the initialization of the form from the cached data. You can supply the`FormGroup`in the`control`parameter of the method, and the`ViewCacheService`
+For persisting form data, the`ViewCacheService`supplies a`formGroup()`method, which manages the
+persistence of any entered form data to the cache and the initialization of the form from the cached
+data. You can supply the`FormGroup`in the`control`parameter of the method, and the`ViewCacheService`
 will:
 
 - Initialize the form the a cached value, if it exists

--- a/docs/architecture/deep-dives/extension-persistence/index.md
+++ b/docs/architecture/deep-dives/extension-persistence/index.md
@@ -97,7 +97,7 @@ Putting this together, the most common implementation pattern would be:
 
 1. **Register the signal** using `ViewCacheService.signal()` on initialization of the component or
    service responsible for the state being persisted
-2. **Restore state from the signal.** If cached data exists, the signal will contain that data. The
+2. **Restore state from the signal:** If cached data exists, the signal will contain that data. The
    component or service should use this data to re-create the state from prior to the popup closing.
 3. **Set new state** in the cache when it changes. Ensure that any updates to the data are persisted
    to the cache with `set()`, so that the cache reflects the latest state

--- a/docs/architecture/deep-dives/extension-persistence/index.md
+++ b/docs/architecture/deep-dives/extension-persistence/index.md
@@ -70,7 +70,7 @@ const mySignal = this.viewCacheService.signal({
 });
 ```
 
-The signal will emit when the value in the cache changes.
+If a cached value exists, the returned signal will contain the cached data.
 
 Setting the value should be done through the signal's `set()` method:
 
@@ -89,6 +89,15 @@ the updated value is not equal to the current signal state. See documentation
 [here](https://angular.dev/guide/signals#signal-equality-functions).
 
 :::
+
+Putting this together, the most common implementation pattern would be:
+
+1. **Register the signal** using `ViewCacheService.signal()` on initialization of the component or
+   service responsible for the state being persisted
+2. **Restore state from the signal.** If cached data exists, the signal will contain that data. The
+   component or service should use this data to re-create the state from prior to the popup closing.
+3. **Set new state** in the cache when it changes. Ensure that any updates to the data are persisted
+   to the cache with `set()`, so that the cache reflects the latest state
 
 #### Caching form data
 

--- a/docs/architecture/deep-dives/extension-persistence/index.md
+++ b/docs/architecture/deep-dives/extension-persistence/index.md
@@ -104,10 +104,10 @@ Putting this together, the most common implementation pattern would be:
 
 #### Caching form data
 
-For persisting form data, the`ViewCacheService`supplies a`formGroup()`method, which manages the
+For persisting form data, the `ViewCacheService` supplies a `formGroup()` method, which manages the
 persistence of any entered form data to the cache and the initialization of the form from the cached
-data. You can supply the`FormGroup`in the`control`parameter of the method, and the`ViewCacheService`
-will:
+data. You can supply the `FormGroup` in the `control` parameter of the method, and the
+`ViewCacheService` will:
 
 - Initialize the form the a cached value, if it exists
 - Save form value to cache when it changes


### PR DESCRIPTION
## 📔 Objective

As more teams are starting to use the `ViewCacheService` for persisting extension data, I had some feedback that it would be good to have some documentation on the framework provided by Platform to do this.

This is my initial attempt at adding documentation.  I'm open to any additions or clarifications, including moving it to a different area of the docs.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
