### PR TITLE
Added links to SDK crate README pages

### DIFF
--- a/docs/getting-started/sdk/internal/index.md
+++ b/docs/getting-started/sdk/internal/index.md
@@ -35,9 +35,12 @@ See the [Tools and Libraries](../../tools/index.md) page for more information.
 The SDK is built for different platforms, all of which have their own build instructions. For more
 information on how to build for a specific platform, refer to the readmes for the different crates:
 
-- **Web**: `crates/bitwarden-wasm-internal`
-- **iOS**: `crates/bitwarden-uniffi/swift`
-- **Android**: `crates/bitwarden-uniffi/kotlin`
+- **Web**:
+  [`crates/bitwarden-wasm-internal`](https://github.com/bitwarden/sdk-internal/tree/main/crates/bitwarden-wasm-internal)
+- **iOS**:
+  [`crates/bitwarden-uniffi/swift`](https://github.com/bitwarden/sdk-internal/tree/main/crates/bitwarden-uniffi/swift)
+- **Android**:
+  [`crates/bitwarden-uniffi/kotlin`](https://github.com/bitwarden/sdk-internal/tree/main/crates/bitwarden-uniffi/kotlin)
 
 Please be aware that each platform has its own set of dependencies that need to be installed before
 building. Make sure to double check the readme if you encounter any issues.


### PR DESCRIPTION
## 📔 Objective

Our `sdk-internal` instructions ask engineers to look at the relevant crate `README` but did not link to those files.  This PR adds links for easy reference.  These felt stable enough to include as links as they should not change frequently.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
