### PR TITLE
Add Localization section to Swift Style Guide

### DIFF
--- a/docs/contributing/code-style/swift.md
+++ b/docs/contributing/code-style/swift.md
@@ -1,7 +1,3 @@
----
-title: Swift
----
-
 # Swift
 
 We use both [SwiftLint](https://github.com/realm/SwiftLint) and
@@ -145,6 +141,33 @@ class ClassName {
   methods without side effects, these should be verb phrases.
 - We prefer "Tapped" instead of "Pressed", "Touched", or "Clicked" when describing buttons or other
   screen elements being tapped, in line with Apple calling this a tap gesture.
+
+## Localization
+
+- We use Crowdin to crowd-source our localizations, based off of the English text. As well, we still
+  use `.strings` files for localization. Therefore only the English `Localizable.strings` file needs
+  to be updated when adding strings; we have regular jobs in GitHub that take care of syncing other
+  translations with Crowdin.
+- Keys in `Localizable.strings` should be a CamelCased string of the English text, rather than a
+  description of where the key is used. As a result, if the English text changes, the key should
+  likewise change—this allows translators in Crowdin to know that they need to likewise update the
+  localized text.
+- Contractions can be converted to un-contracted form in the key, particularly if it aids with
+  readability.
+- If the string in question is particularly long, a truncated form with `DescriptionLong` appended
+  is reasonable.
+- If possible, keys (and therefore corresponding localized text) should be the same between iOS and
+  Android.
+- We have not been particularly consistent about this in the past, but are working to unify against
+  these standards.
+
+Some examples:
+
+```text
+"UseFingerprintToUnlock" = "Use fingerprint to unlock";
+"EncryptionKeyMigrationRequiredDescriptionLong" = "Encryption key migration required. Please login through the web vault to update your encryption key.";
+"YouAreAllSet" = "You're all set!";
+```
 
 ## File Names
 


### PR DESCRIPTION
## 📔 Objective

This adds a section to discuss our approach to localization in the iOS applications. This is inspired by a recent Community PR where someone was not aware of our approach and needed to make changes on review because of it.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
