### PR TITLE
Add documentation of minimum release age in our Renovate config

### DIFF
--- a/docs/contributing/dependencies/index.md
+++ b/docs/contributing/dependencies/index.md
@@ -27,6 +27,8 @@ The default configuration:
   the workload.
 - Manages updates with semantic versioning and lock file updates. Rebases are disabled.
 - Allows an unlimited number of pull requests to be created.
+- Delays creation of pull requests until at least seven days after the dependency version release,
+  to ensure any post-release security issues are addressed.
 - Includes major updates (the latest) as individual pull requests. Monorepo updates are also
   grouped.
 - Schedules runs to happen on the weekend when more Actions workers are likely available for the

--- a/docs/contributing/dependencies/index.md
+++ b/docs/contributing/dependencies/index.md
@@ -28,7 +28,7 @@ The default configuration:
 - Manages updates with semantic versioning and lock file updates. Rebases are disabled.
 - Allows an unlimited number of pull requests to be created.
 - Delays creation of pull requests until at least seven days after the dependency version release,
-  to ensure any post-release security issues are addressed.
+  to ensure stability of said release from bugs and / or security issues.
 - Includes major updates (the latest) as individual pull requests. Monorepo updates are also
   grouped.
 - Schedules runs to happen on the weekend when more Actions workers are likely available for the


### PR DESCRIPTION
## 📔 Objective

In #583 I added additional documentation on our dependency management process.  I neglected to add anything describing our `minimumReleaseAge` policy, which is an important part of the trust we put in the dependency updates that we review.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
