### PR TITLE
Remove unused evolutionary database design processes

### DIFF
--- a/docs/contributing/database-migrations/index.md
+++ b/docs/contributing/database-migrations/index.md
@@ -5,26 +5,28 @@ sidebar_position: 2
 # Database migrations
 
 In accordance with the tenets of [Evolutionary Database Design](./edd.mdx), each change needs to be
-considered to be split into two parts:
+considered to be split into three parts:
 
-1. A transition (backwards-compatible) migration
-2. A finalization (breaking-change) migration
+1. An initial change that is backwards compatible
+2. A transition change that migrates data and procedures
+3. A finalization change containing breaking changes
+
+The initial and transition changes are typically released simultaneously. They must be in separate
+migration files.
 
 Migrations must follow Bitwarden's
 [self-hosted server release policy](https://bitwarden.com/help/bitwarden-software-release-support/#bitwarden-self-hosted-server).
 This implies a staged migration cycle, as follows:
 
 1. Release the initial migration
-2. Release the transition migration (this may be combined with the initial release)
-3. Wait at least 1 major server version
+2. Release the transition migration
+3. Skip at least 1 major server version
 4. Release the finalization migration
 
 :::note
 
 When your change does not introduce breaking changes (i.e. all changes are backwards-compatible in
-their final form), only the transition phase is required.
-
-:::
+their final form), only the initial and transition migrations occur. :::
 
 ## Applying migrations
 

--- a/docs/contributing/database-migrations/index.md
+++ b/docs/contributing/database-migrations/index.md
@@ -4,6 +4,26 @@ sidebar_position: 2
 
 # Database migrations
 
+In accordance with the tenets of [Evolutionary Database Design](./edd.mdx), each change needs to be
+considered to be split into two parts:
+
+1. A backwards-compatible migration
+2. A breaking-change migration
+
+Backwards compatible migrations should remain in place for at least one full release before being
+removed to mitigate the risk of data loss. This implies a staged migration cycle, as follows:
+
+1. Release the backwards-compatible transition migration
+2. Wait at least 1 release
+3. Release the breaking-change migration
+
+:::note
+
+It is possible that a change may not introduce breaking changes (i.e. all changes may be
+backwards-compatible in their final form). In that case, only one phase of changes is required.
+
+:::
+
 ## Applying migrations
 
 We use a `migrate.ps1` PowerShell script to apply migrations to the local development database. This
@@ -22,15 +42,13 @@ for Entity Framework. Follow the instructions below for each provider.
 
 :::tip
 
-We recommend reading [Evolutionary Database Design](./edd.mdx) and [T-SQL Code
-Style][code-style-sql] first, since they have a major impact in how we write migrations.
+We recommend reading [T-SQL Code Style][code-style-sql] first, since it has a major impact in how we
+write migrations.
 
 :::
 
-:::info
-
-The separate database definitions in `src/Sql/.../dbo` serve as a "master" reference for the
-intended and final state of the database at that time. This is crucial because the state of database
+The separate database definitions in `src/Sql/.../dbo` serve as the source of truth for the intended
+and final state of the database at that time. This is crucial because the state of database
 definitions at the current moment may differ from when a migration was added in the past. These
 definitions act as a lint and validation step to ensure that migrations work as expected, and the
 separation helps maintain clarity and accuracy in database schema management and synchronization
@@ -43,34 +61,9 @@ is in place; however, instead of using the auto-generated migrations from
 we manually write migrations. This approach is chosen to enhance performance and prevent accidental
 data loss, which is why we have both a `sqlproj` and standalone migrations.
 
-:::
-
-In accordance with the tenets of [Evolutionary Database Design](./edd.mdx), each change needs to be
-considered to be split into two parts:
-
-1. A backwards-compatible transition migration
-2. A non-backwards-compatible final migration
-
-It is possible that a change may not require a non-backwards-compatible end phase (i.e. all changes
-may be backwards-compatible in their final form). In that case, only one phase of changes is
-required.
-
-#### Backwards compatible migration
-
 1. Modify the source `.sql` files in `src/Sql/dbo`.
 2. Write a migration script, and place it in `util/Migrator/DbScripts`. Each script must be prefixed
    with the current date.
-
-#### Non-backwards compatible migration
-
-1. Copy the relevant `.sql` files from `src/Sql/dbo` to `src/Sql/dbo_finalization`.
-2. Remove the backwards compatibility that is no longer needed.
-3. Write a new Migration and place it in `src/Migrator/DbScripts_finalization`. Name it
-   `YYYY-0M-FinalizationMigration.sql`.
-   - Typically migrations are designed to be run in sequence. However since the migrations in
-     DbScripts_finalization can be run out of order, care must be taken to ensure they remain
-     compatible with the changes to DbScripts. In order to achieve this we only keep a single
-     migration, which executes all backwards incompatible schema changes.
 
 ### EF migrations
 
@@ -89,16 +82,5 @@ pwsh ef_migrate.ps1 [NAME_OF_MIGRATION]
 ```
 
 This will generate the migrations, which should then be included in your PR.
-
-### [Not Yet Implemented] Manual MSSQL migrations
-
-There may be a need for a migration to be run outside of our normal update process. These types of
-migrations should be saved for very exceptional purposes. One such reason could be an Index rebuild.
-
-1. Write a new Migration with a prefixed current date and place it in
-   `src/Migrator/DbScripts_manual`
-2. After it has been run against our Cloud environments and we are satisfied with the outcome,
-   create a PR to move it to `DbScripts`. This will enable it to be run by our Migrator processes in
-   self-host and clean installs of both cloud and self-host environments
 
 [code-style-sql]: ../code-style/sql.md

--- a/docs/contributing/database-migrations/index.md
+++ b/docs/contributing/database-migrations/index.md
@@ -10,17 +10,17 @@ considered to be split into two parts:
 1. A backwards-compatible migration
 2. A breaking-change migration
 
-Backwards compatible migrations should remain in place for at least one full release before being
-removed to mitigate the risk of data loss. This implies a staged migration cycle, as follows:
+Migrations must follow Bitwarden's [self-hosted server release policy](release-policy). This implies
+a staged migration cycle, as follows:
 
-1. Release the backwards-compatible transition migration
-2. Wait at least 1 release
+1. Release the backwards-compatible migration
+2. Wait at least 1 major server version
 3. Release the breaking-change migration
 
 :::note
 
-It is possible that a change may not introduce breaking changes (i.e. all changes may be
-backwards-compatible in their final form). In that case, only one phase of changes is required.
+When your change does not introduce breaking changes (i.e. all changes are backwards-compatible in
+their final form), only one phase of changes is required.
 
 :::
 
@@ -83,4 +83,6 @@ pwsh ef_migrate.ps1 [NAME_OF_MIGRATION]
 
 This will generate the migrations, which should then be included in your PR.
 
+[release-policy]:
+  https://bitwarden.com/help/bitwarden-software-release-support/#bitwarden-self-hosted-server
 [code-style-sql]: ../code-style/sql.md

--- a/docs/contributing/database-migrations/index.md
+++ b/docs/contributing/database-migrations/index.md
@@ -7,21 +7,22 @@ sidebar_position: 2
 In accordance with the tenets of [Evolutionary Database Design](./edd.mdx), each change needs to be
 considered to be split into two parts:
 
-1. A backwards-compatible migration
-2. A breaking-change migration
+1. A transition (backwards-compatible) migration
+2. A finalization (breaking-change) migration
 
 Migrations must follow Bitwarden's
 [self-hosted server release policy](https://bitwarden.com/help/bitwarden-software-release-support/#bitwarden-self-hosted-server).
 This implies a staged migration cycle, as follows:
 
-1. Release the backwards-compatible migration
-2. Wait at least 1 major server version
-3. Release the breaking-change migration
+1. Release the initial migration
+2. Release the transition migration (this may be combined with the initial release)
+3. Wait at least 1 major server version
+4. Release the finalization migration
 
 :::note
 
 When your change does not introduce breaking changes (i.e. all changes are backwards-compatible in
-their final form), only one phase of changes is required.
+their final form), only the transition phase is required.
 
 :::
 

--- a/docs/contributing/database-migrations/index.md
+++ b/docs/contributing/database-migrations/index.md
@@ -10,8 +10,9 @@ considered to be split into two parts:
 1. A backwards-compatible migration
 2. A breaking-change migration
 
-Migrations must follow Bitwarden's [self-hosted server release policy](release-policy). This implies
-a staged migration cycle, as follows:
+Migrations must follow Bitwarden's
+[self-hosted server release policy](https://bitwarden.com/help/bitwarden-software-release-support/#bitwarden-self-hosted-server).
+This implies a staged migration cycle, as follows:
 
 1. Release the backwards-compatible migration
 2. Wait at least 1 major server version
@@ -83,6 +84,4 @@ pwsh ef_migrate.ps1 [NAME_OF_MIGRATION]
 
 This will generate the migrations, which should then be included in your PR.
 
-[release-policy]:
-  https://bitwarden.com/help/bitwarden-software-release-support/#bitwarden-self-hosted-server
 [code-style-sql]: ../code-style/sql.md


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Align documentation with present evolutionary database design processes, which manage breaking changes by spanning them across several releases.

[Rendered document](https://remove-unused-edd-processes.contributing-docs.pages.dev/contributing/database-migrations/)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
