### PR TITLE
confirm passwords match between .env and secrets.json

### DIFF
--- a/docs/getting-started/server/database/ef/index.mdx
+++ b/docs/getting-started/server/database/ef/index.mdx
@@ -59,53 +59,6 @@ chronological order.
 You can have multiple databases configured and switch between them by changing the value of the
 `globalSettings:databaseProvider` user secret. You don’t have to delete your connection strings.
 
-### Database Setup
-
-<Tabs
-    groupId="provider"
-    values={providers}>
-<TabItem value="postgres">
-
-In the `dev` folder of your server repository, run
-
-```bash
-export POSTGRES_PASSWORD='example'
-docker compose --profile postgres up
-```
-
-:::note
-
-`POSTGRES_PASSWORD` only needs to be defined for database setup. It does not need to be defined to
-run the mysql profile.
-
-:::
-
-</TabItem>
-<TabItem value="mysql">
-
-In the `dev` folder of your server repository, run
-
-```bash
-export MYSQL_ROOT_PASSWORD='example'
-docker compose --profile mysql up
-```
-
-:::note
-
-`MYSQL_ROOT_PASSWORD` only needs to be defined for database setup. It does not need to be defined to
-run the mysql profile.
-
-:::
-
-</TabItem>
-<TabItem value="sqlite">
-
-Select a location for your database file. You can use the `dev` folder of your server repository.
-Git is configured to ignore `.db` files in this repository for this purpose.
-
-</TabItem>
-</Tabs>
-
 ### User secrets
 
 Add the following values to your API, Identity, and Admin user secrets.
@@ -155,6 +108,41 @@ that the changes take effect.
 
 :::
 
+### Database Setup
+
+<Tabs
+    groupId="provider"
+    values={providers}>
+<TabItem value="postgres">
+
+1. Confirm that `POSTGRES_PASSWORD` in `dev/.env` matches the password in `dev/secrets.json`.
+
+2. In the `dev` folder of your server repository, run
+
+```bash
+docker compose --profile postgres up
+```
+
+</TabItem>
+<TabItem value="mysql">
+
+1. Confirm that `MYSQL_ROOT_PASSWORD` in `dev/.env` matches the password in `dev/secrets.json`.
+
+2. In the `dev` folder of your server repository, run
+
+```bash
+docker compose --profile mysql up
+```
+
+</TabItem>
+<TabItem value="sqlite">
+
+Select a location for your database file. You can use the `dev` folder of your server repository.
+Git is configured to ignore `.db` files in this repository for this purpose.
+
+</TabItem>
+</Tabs>
+
 ### Migrations
 
 <Tabs
@@ -168,7 +156,7 @@ In the `dev` folder run the following to update the database to the latest migra
 pwsh migrate.ps1 -postgres
 ```
 
-The `-postgres` flag on `migrate.ps1` will run `dotnet ef` commands to perform the migrations.
+The `-postgres` flag on `migrate.ps1` runs `dotnet ef` commands to perform the migrations.
 
 </TabItem>
 <TabItem value="mysql">
@@ -179,7 +167,7 @@ In the `dev` folder run the following to update the database to the latest migra
 pwsh migrate.ps1 -mysql
 ```
 
-The `-mysql` flag on `migrate.ps1` will run `dotnet ef` commands to perform the migrations.
+The `-mysql` flag on `migrate.ps1` runs `dotnet ef` commands to perform the migrations.
 
 </TabItem>
 <TabItem value="sqlite">
@@ -190,7 +178,7 @@ In the `dev` folder run the following to update the database to the latest migra
 pwsh migrate.ps1 -sqlite
 ```
 
-The `-sqlite` flag on `migrate.ps1` will run `dotnet ef` commands to perform the migrations.
+The `-sqlite` flag on `migrate.ps1` runs `dotnet ef` commands to perform the migrations.
 
 :::note
 

--- a/docs/getting-started/server/database/ef/index.mdx
+++ b/docs/getting-started/server/database/ef/index.mdx
@@ -91,19 +91,13 @@ sure you update the existing values instead of creating new ones
 <TabItem value="sqlite">
 
 Add the following values to your API, Identity, and Admin user secrets. Note, you must set the Data
-Source path.
+Source path. Git is configured to ignore `.db` files in the server repository so that the sqlite
+database can be stored in `dev`. You can use any path with write permissions.
 
 ```json
 "globalSettings:databaseProvider": "sqlite",
 "globalSettings:sqlite:connectionString": "Data Source=/path/to/your/server/repo/dev/bitwarden.db",
 ```
-
-:::note
-
-Git is configured to ignore `.db` files in the server repository so that the sqlite database can be
-stored in `dev`. You can use any path with write permissions.
-
-:::
 
 </TabItem>
 </Tabs>

--- a/docs/getting-started/server/database/ef/index.mdx
+++ b/docs/getting-started/server/database/ef/index.mdx
@@ -123,6 +123,14 @@ that the changes take effect.
 docker compose --profile postgres up
 ```
 
+:::tip[Confirm your database connection!]
+
+If you run into connection errors, double check that your `.env` and `secrets.json` files have
+matching passwords. If they do, you may have initialized your database incorrectly. Delete the
+Docker storage volume and initialize the database from scratch.
+
+:::
+
 </TabItem>
 <TabItem value="mysql">
 
@@ -134,15 +142,6 @@ docker compose --profile postgres up
 docker compose --profile mysql up
 ```
 
-</TabItem>
-<TabItem value="sqlite">
-
-Select a location for your database file. You can use the `dev` folder of your server repository.
-Git is configured to ignore `.db` files in this repository for this purpose.
-
-</TabItem>
-</Tabs>
-
 :::tip[Confirm your database connection!]
 
 If you run into connection errors, double check that your `.env` and `secrets.json` files have
@@ -150,6 +149,23 @@ matching passwords. If they do, you may have initialized your database incorrect
 Docker storage volume and initialize the database from scratch.
 
 :::
+
+</TabItem>
+<TabItem value="sqlite">
+
+Select a location for your database file. You can use the `dev` folder of your server repository.
+Git is configured to ignore `.db` files in this repository for this purpose.
+
+:::tip[Confirm your database path!]
+
+The migrator creates the database file if it doesn't exist, but it does not create folders. If you
+get an error that the path doesn't exist, double check that the path exists and that the folder
+containing the sqlite database has write and/or create permissions.
+
+:::
+
+</TabItem>
+</Tabs>
 
 ### Migrations
 

--- a/docs/getting-started/server/database/ef/index.mdx
+++ b/docs/getting-started/server/database/ef/index.mdx
@@ -91,12 +91,19 @@ sure you update the existing values instead of creating new ones
 <TabItem value="sqlite">
 
 Add the following values to your API, Identity, and Admin user secrets. Note, you must set the Data
-Source path. Use the file location selected in [Database Setup](#database-setup)
+Source path.
 
 ```json
 "globalSettings:databaseProvider": "sqlite",
 "globalSettings:sqlite:connectionString": "Data Source=/path/to/your/server/repo/dev/bitwarden.db",
 ```
+
+:::note
+
+Git is configured to ignore `.db` files in the server repository so that the sqlite database can be
+stored in `dev`. You can use any path with write permissions.
+
+:::
 
 </TabItem>
 </Tabs>
@@ -152,9 +159,6 @@ Docker storage volume and initialize the database from scratch.
 
 </TabItem>
 <TabItem value="sqlite">
-
-Select a location for your database file. You can use the `dev` folder of your server repository.
-Git is configured to ignore `.db` files in this repository for this purpose.
 
 :::tip[Confirm your database path!]
 
@@ -265,8 +269,3 @@ existing databases if you have not already. If these settings are not present at
 With connection strings applied to your projects: ensure your databases are all migrated using
 `pwsh server/dev/migrate.ps1 --all`. Then you can run EF tests from the
 `test/Infrastructure.IntegrationTest` folder using `dotnet test`.
-
-## Modifying the database
-
-The process for modifying the database is described in
-[Migrations](./../../../../../contributing/database-migrations/ef.md).

--- a/docs/getting-started/server/database/ef/index.mdx
+++ b/docs/getting-started/server/database/ef/index.mdx
@@ -143,6 +143,14 @@ Git is configured to ignore `.db` files in this repository for this purpose.
 </TabItem>
 </Tabs>
 
+:::tip[Confirm your database connection!]
+
+If you run into connection errors, double check that your `.env` and `secrets.json` files have
+matching passwords. If they do, you may have initialized your database incorrectly. Delete the
+Docker storage volume and initialize the database from scratch.
+
+:::
+
 ### Migrations
 
 <Tabs

--- a/docs/getting-started/server/database/ef/index.mdx
+++ b/docs/getting-started/server/database/ef/index.mdx
@@ -269,4 +269,4 @@ With connection strings applied to your projects: ensure your databases are all 
 ## Modifying the database
 
 The process for modifying the database is described in
-[Migrations](./../../../../contributing/database-migrations/ef.md).
+[Migrations](./../../../../../contributing/database-migrations/ef.md).

--- a/docs/getting-started/server/database/ef/index.mdx
+++ b/docs/getting-started/server/database/ef/index.mdx
@@ -40,9 +40,9 @@ each.
 
 Our EF implementations currently support Postgres, MySQL, and SQLite3.
 
-## Setting Up EF Databases
+## Creating the database
 
-The workflow here is broadly the same as with the normal MSSQL implementation: set up the docker
+The workflow here is broadly the same as with the normal MSSQL implementation: set up the Docker
 container, configure user secrets, and run migrations against their relating databases in
 chronological order.
 
@@ -108,7 +108,7 @@ that the changes take effect.
 
 :::
 
-### Database Setup
+### Updating the database
 
 <Tabs
     groupId="provider"
@@ -220,7 +220,7 @@ You can also run migrations for all database providers at once using
 pwsh migrate.ps1 -all
 ```
 
-### Optional: Verify
+### Verifying changes
 
 If you would like to verify that everything worked correctly:
 
@@ -229,7 +229,7 @@ If you would like to verify that everything worked correctly:
   - Note: this requires a configured MSSQL database. You may also need to set up other EF providers
     for tests to pass.
 
-## Testing EF Changes
+## Testing changes
 
 In your `server/dev/secrets.json` file find or add this block of secrets in the root of the json
 structure:
@@ -265,3 +265,8 @@ existing databases if you have not already. If these settings are not present at
 With connection strings applied to your projects: ensure your databases are all migrated using
 `pwsh server/dev/migrate.ps1 --all`. Then you can run EF tests from the
 `test/Infrastructure.IntegrationTest` folder using `dotnet test`.
+
+## Modifying the database
+
+The process for modifying the database is described in
+[Migrations](./../../../../contributing/database-migrations/ef.md).


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

@justindbaur pointed out that there's a `.env` file, so I've adjusted the instructions to include a step confirming the environment variables match.

This PR also moves the application config above the database config so that a reader encounters `secrets.json` before it's referenced by the database config section's tips.

([rendered](https://add-dot-env-reminder.contributing-docs.pages.dev/getting-started/server/database/ef/))

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
