### PR TITLE
[PM-22132] Bugfix - Have workflows use the version of node specified in the project files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
+          node-version-file: ".nvmrc"
 
       - name: Build
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
+          node-version-file: ".nvmrc"
 
       - name: Lint and spellcheck
         run: |


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22030](https://bitwarden.atlassian.net/browse/PM-22030)

## 📔 Objective

The `contributing-docs` build checks will begin failing as of the [latest version bump to cspell](https://github.com/bitwarden/contributing-docs/pull/598), owning to the workflow using node v18 instead of the project-defined version (v22).

Consequently, the `npm run spellcheck` script works locally with the correct node version running, but fails in the action runners.

![Screenshot 2025-05-27 at 5 25 39 PM](https://github.com/user-attachments/assets/2b8398e5-2546-4d55-adef-1f2e6c9c642e)

![Screenshot 2025-05-27 at 5 25 59 PM](https://github.com/user-attachments/assets/554aad2e-d3b6-45bf-a43a-4e266e5f90c8)

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22030]: https://bitwarden.atlassian.net/browse/PM-22030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ