### PR TITLE
Recommend same type and value name for enums

### DIFF
--- a/docs/contributing/code-style/enums.md
+++ b/docs/contributing/code-style/enums.md
@@ -78,7 +78,7 @@ export function asCipherType(value: number): CipherType | undefined {
   return isCipherType(value) ? value : undefined;
 }
 
-export function nameOfCipherType(name: CipherType): keyof CipherType | undefined {
+export function nameOfCipherType(value: CipherType): keyof CipherType | undefined {
   return namesByCipherType.get(value);
 }
 ```


### PR DESCRIPTION
Use the same name for the type and the value allows us to emulate regular Enums much better.

[Rendered](https://coroiu-update-const-recommen.contributing-docs.pages.dev/contributing/code-style/enums)

## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Improve recommendation of const object as enums

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
