### PR TITLE
fix(safari-prod-build-instructions): Replace deprecated npm run dist:safari:dmg with new npm run dist:safari

### DIFF
--- a/docs/getting-started/clients/browser/biometric.mdx
+++ b/docs/getting-started/clients/browser/biometric.mdx
@@ -53,9 +53,9 @@ instead.
 ### Build and Run the Browser Extension
 
 - In the local Browser project, run `npm ci`.
-- To use the local browser extension on Safari, use this command: `npm run dist:safari:dmg`. Once
-  this has built, you should see the Bitwarden Extension in Safari's Settings under Extensions menu.
-  If not, open and build the related Xcode project (usually found in
+- To use the local browser extension on Safari, use this command: `npm run dist:safari`. Once this
+  has built, you should see the Bitwarden Extension in Safari's Settings under Extensions menu. If
+  not, open and build the related Xcode project (usually found in
   `$HOME/browser/dist/Safari/dmg/desktop.xcodeproj`). It should then show up in the Settings
   Extensions menu, and you can enable it.
 - For other browsers, use `npm run build:watch` and then load the locally built extension using the

--- a/docs/getting-started/clients/browser/index.md
+++ b/docs/getting-started/clients/browser/index.md
@@ -228,7 +228,7 @@ the extension for every change, which is slower.
 1.  Build the extension for Safari
 
     ```bash
-    npm run dist:safari:dmg
+    npm run dist:safari
     ```
 
 2.  Open Safari and check Settings to confirm that the extension is installed and enabled


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
n/a

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
To correct the now outdated safari build commands which were deprecated by https://github.com/bitwarden/clients/pull/12033.

I found this by trying to follow our [docs](https://contributing.bitwarden.com/getting-started/clients/browser/#production-build) on running the extension in Safari. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
