### PR TITLE
Safari now supports unpacked temporary extension - no need to run it through xcode

### DIFF
--- a/docs/getting-started/clients/browser/biometric.mdx
+++ b/docs/getting-started/clients/browser/biometric.mdx
@@ -52,14 +52,54 @@ instead.
 
 ### Build and Run the Browser Extension
 
-- In the local Browser project, run `npm ci`.
-- To use the local browser extension on Safari, use this command: `npm run dist:safari`. Once this
-  has built, you should see the Bitwarden Extension in Safari's Settings under Extensions menu. If
-  not, open and build the related Xcode project (usually found in
-  `$HOME/browser/dist/Safari/dmg/desktop.xcodeproj`). It should then show up in the Settings
-  Extensions menu, and you can enable it.
-- For other browsers, use `npm run build:watch` and then load the locally built extension using the
-  method described [here](./index.md#testing-and-debugging).
+1. In the local Browser project, run `npm ci`.
+2. Build the extension:
+
+   ```bash
+   npm run build:watch
+   ```
+
+3. Load the locally built extension using the method described
+   [here](./index.md#testing-and-debugging).
+
+### Safari
+
+Safari requires a different build process compared to other browsers. The extension must be packaged
+as a desktop application, which is then installed in Safari.
+
+#### Through Xcode
+
+1. In the local Browser project, run `npm ci`.
+2. Build the extension:
+
+   ```bash
+   npm run dist:safari
+   ```
+
+3. Open `src/safari/desktop.xcodeproj` in Xcode
+4. Run the "desktop" target.
+5. You should see the Bitwarden Extension in Safari's Settings under Extensions menu.
+
+:::note
+
+Please remember to re-run through Xcode whenever any changes are made to the source files. It will
+not automatically reload.
+
+:::
+
+#### Production build
+
+1. In the local Browser project, run `npm ci`.
+2. Build the extension:
+
+   ```bash
+   npm run build:watch:safari
+   ```
+
+3. You should see the Bitwarden Extension in Safari's Settings under Extensions menu. If not, open
+   and build the related Xcode project (usually found in
+   `browser/dist/Safari/dmg/desktop.xcodeproj`). It should then show up in the Settings Extensions
+   menu, and you can enable it.
 
 ### Build and Run the Desktop App
 

--- a/docs/getting-started/clients/browser/index.md
+++ b/docs/getting-started/clients/browser/index.md
@@ -176,48 +176,27 @@ the Bitwarden heading in the Temporary Extensions page. To debug the popup:
 
 ### Safari
 
-Safari WebExtensions must be distributed through the Mac App Store, bundled with a regular Mac App
-Store application. Due to this the build and debug process is slightly different compared to the
-other browsers.
+To load the browser extension build:
 
-#### Uninstall previous versions
-
-If you’ve built, installed or ran the Desktop client before (including the official release), Safari
-will most likely continue to load the official Browser extension and not the version you’ve built
-from source.
-
-To avoid this, follow the instructions below to uninstall the Safari extension:
-
-1.  Open Safari
-2.  Click “Settings” and then click the “Extensions” tab
-3.  Click uninstall next to the Bitwarden extension
-4.  Delete the Application with the extension.
-5.  Reopen Safari and check Settings to confirm that there is no Bitwarden Browser extension
-    installed. In case there still is a Bitwarden Extension please repeat step 3-4.
-6.  Quit and completely close Safari
-
-You may need to do this periodically if you are loading the Browser extension from different sources
-(for example, switching between a local build and the official release).
-
-#### Developing in Xcode
-
-The easiest way to develop the extension is to build and debug it using Xcode.
-
-1. Build the extension:
+1. Build the extension for Safari:
 
    ```bash
    npm run build:watch:safari
    ```
 
-2. Open `src/safari/desktop.xcodeproj` in Xcode
-3. Run the "desktop" target.
+2. Open Safari and navigate to `Safari -> Settings -> Developer`
+3. Click “Allow unsigned extensions”
+4. Click “Add Temporary Extension...”
+5. Open the `build` folder of your local repository
 
-:::note
+You will now have your local build of the browser extension installed.
 
-Please remember to re-run through Xcode whenever any changes are made to the source files. It will
-not automatically reload.
+The temporary extension will only be installed for the current session. If you close and re-open
+Safari, you will have to load the temporary extension again.
 
-:::
+You can debug the background page of the browser extension by clicking
+`Develop -> Web Extension Background Pages` and then selecting Bitwarden. You can debug the popup by
+right-clicking it while it is open and clicking "Inspect Element".
 
 #### Production build
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Simplify safari instructions

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
