### PR TITLE
Self-hosted guide clarify context to run sqlcmd from

### DIFF
--- a/docs/getting-started/server/self-hosted/index.mdx
+++ b/docs/getting-started/server/self-hosted/index.mdx
@@ -125,7 +125,8 @@ database up-to-date with any migrations.
 
 You need to manually add the Installation key to your cloud-configured instance, so that it knows
 about your self-hosted instance and will allow access when API calls need to be made between the
-two. Feel free to do this with any database management tool or the below script:
+two. Feel free to do this with any database management tool or the below script, which can be
+executed from within the mssql container:
 
 ```bash
 /opt/mssql-tools/bin/sqlcmd -S mssql -d vault_dev -U sa -P <<SA_PASSWORD>> -I -i <<SCRIPT_FILE>>

--- a/docs/getting-started/server/self-hosted/index.mdx
+++ b/docs/getting-started/server/self-hosted/index.mdx
@@ -126,7 +126,7 @@ database up-to-date with any migrations.
 You need to manually add the Installation key to your cloud-configured instance, so that it knows
 about your self-hosted instance and will allow access when API calls need to be made between the
 two. Feel free to do this with any database management tool or the below script, which can be
-executed from within the mssql container:
+executed from within the `mssql` container:
 
 ```bash
 /opt/mssql-tools/bin/sqlcmd -S mssql -d vault_dev -U sa -P <<SA_PASSWORD>> -I -i <<SCRIPT_FILE>>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

To make it clear that the sqlcmd command referenced, should be run from the context of the mssql container.
There otherwise currently isn't any indication on where to run that command from such that it has the desired effect.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
