### PR TITLE
add steps and reasons for using a hardware backed commit signing key

### DIFF
--- a/docs/contributing/commit-signing.mdx
+++ b/docs/contributing/commit-signing.mdx
@@ -86,6 +86,21 @@ extracted or copied.
 
 #### Setting up sk-ed25519 Keys
 
+:::note macOS Users
+
+On macOS, you'll need to install OpenSSH via Homebrew as the system's built-in OpenSSH lacks proper
+FIDO2 support:
+
+```bash
+brew install openssh
+```
+
+After installation, restart your terminal to ensure the Homebrew version is used. If it's not then
+fully qualify the path to the homebrew version of ssh-keygen in the example, like
+`/opt/homebrew/bin/ssh-keygen [everything else]`.
+
+:::
+
 1. Generate an sk-ed25519 key for commit signing:
 
    ```bash
@@ -115,7 +130,7 @@ extracted or copied.
 #### Hardware Key Requirements
 
 - **FIDO2/U2F compatible security key** (YubiKey 5 series, SoloKeys, etc.)
-- **OpenSSH 8.2+** with FIDO2 support
+- **OpenSSH 8.2+** with FIDO2 support (on macOS, install via Homebrew: `brew install openssh`)
 - **Physical access** to the security key for each signing operation
 
 #### Fallback Strategy


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

The contributing docs only example for a commit signing key is a standard ed25519. This is fine, but since most of the developers on Bitwarden have yubikeys it leaves some security improvements on the floor. This PR adds a subsection explaining the pros of using a hardware backed signing key and shows what to do differently from the base guide to get one.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
