### PR TITLE
Improve emphasis on engaging in discussion before significant PRs

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -15,18 +15,22 @@ Here is how you can get involved:
 
 - **Request a new feature:** Go to the
   [Feature Requests category](https://community.bitwarden.com/c/feature-requests/) of the Community
-  Forums. Please search existing feature requests before making a new one
-- **Write code for a new feature:** Make a new post in the
+  Forums. Please search existing feature requests before making a new one.
+- **Write code for a new feature or bug fix:** By submitting a pull request. :::note _Before_
+  writing code for either a new feature or a bug fix that has significant or UX changes, significant
+  changes, make a new post in the
   [Password Manager](https://github.com/orgs/bitwarden/discussions/categories/password-manager) or
   [Secrets Manager](https://github.com/orgs/bitwarden/discussions/categories/secrets-manager) GitHub
   Discussions category. Include a description of your proposed contribution, screenshots, and links
-  to any relevant feature requests. This helps get feedback from the community and Bitwarden team
-  members before you start writing code
-- **Report a bug or submit a bugfix:** Use Github issues and pull requests
+  to any relevant feature requests or issues. This helps get feedback from the community and
+  Bitwarden team members before you start writing code and facilitates a smoother PR review process.
+  :::
+
+- **Report a bug:** Using Github issues.
 - **Help other users:** Go to the
   [Ask the Bitwarden Community category](https://community.bitwarden.com/c/support/) on the
-  Community Forums
-- **Translate:** See the localization (i10n) section below
+  Community Forums.
+- **Translate:** See the localization (i10n) section below.
 - **Report a security concern or vulnerability:** Security audits and feedback are welcome. If the
   issue is sensitive, please [contact us privately](https://bitwarden.com/contact) or submit a
   report through our [HackerOne Program](https://hackerone.com/bitwarden/). You can read our

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -16,9 +16,10 @@ Here is how you can get involved:
 - **Request a new feature:** Go to the
   [Feature Requests category](https://community.bitwarden.com/c/feature-requests/) of the Community
   Forums. Please search existing feature requests before making a new one.
-- **Write code for a new feature or bug fix:** By submitting a pull request. :::note _Before_
-  writing code for either a new feature or a bug fix that has significant or UX changes, significant
-  changes, make a new post in the
+- **Write code for a new feature or bug fix:** By submitting a pull request.
+
+  :::note _Before_ writing code for either a new feature or a bug fix that has significant or UX
+  changes, significant make a new post in the
   [Password Manager](https://github.com/orgs/bitwarden/discussions/categories/password-manager) or
   [Secrets Manager](https://github.com/orgs/bitwarden/discussions/categories/secrets-manager) GitHub
   Discussions category. Include a description of your proposed contribution, screenshots, and links

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -18,8 +18,8 @@ Here is how you can get involved:
   Forums. Please search existing feature requests before making a new one.
 - **Write code for a new feature or bug fix:** By submitting a pull request.
 
-  :::note _Before_ writing code for either a new feature or a bug fix that has significant or UX
-  changes, significant make a new post in the
+  :::note _Before_ writing code for either a new feature or a bug fix that has significant UX
+  changes, make a new post in the
   [Password Manager](https://github.com/orgs/bitwarden/discussions/categories/password-manager) or
   [Secrets Manager](https://github.com/orgs/bitwarden/discussions/categories/secrets-manager) GitHub
   Discussions category. Include a description of your proposed contribution, screenshots, and links


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Improve the contributing guide to emphasize engaging in GH discussions for changes due to new features or significant bug fixes before opening PRs.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
