### PR TITLE
Fix rendering of note box before writing code

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -18,13 +18,16 @@ Here is how you can get involved:
   Forums. Please search existing feature requests before making a new one.
 - **Write code for a new feature or bug fix:** By submitting a pull request.
 
-  :::note _Before_ writing code for either a new feature or a bug fix that has significant UX
-  changes, make a new post in the
+  :::note
+
+  _Before_ writing code for either a new feature or a bug fix that has significant UX changes,
+  please make a new post in the
   [Password Manager](https://github.com/orgs/bitwarden/discussions/categories/password-manager) or
   [Secrets Manager](https://github.com/orgs/bitwarden/discussions/categories/secrets-manager) GitHub
   Discussions category. Include a description of your proposed contribution, screenshots, and links
   to any relevant feature requests or issues. This helps get feedback from the community and
   Bitwarden team members before you start writing code and facilitates a smoother PR review process.
+
   :::
 
 - **Report a bug:** Using Github issues.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Currently the rendering of the newly added note box for bringing attention to using GH discussions has the beginning of the note contents rendering on the same line as the Note text, which is wrong and inconsistent. This PR fixes that by adding the newlines after/before the note declaration syntax.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
