### PR TITLE
Add section about testing desktop mac store builds

### DIFF
--- a/docs/getting-started/clients/desktop/mac/index.md
+++ b/docs/getting-started/clients/desktop/mac/index.md
@@ -63,7 +63,7 @@ security add-generic-password -a "<apple_id>" -w "<app_specific_password>" -s "A
 3. Install the provisioning profile to your device, and place it the `clients/apps/desktop`
    repository root.
 
-## Testing
+### Building
 
 1. Identify the name of your personal development certificate by running:
    ```zsh
@@ -74,14 +74,25 @@ security add-generic-password -a "<apple_id>" -w "<app_specific_password>" -s "A
 
 3. Run `npm run dist:mac:masdev`.
 
-:::info
+   :::info
 
-If this is your first time running desktop locally, be sure to run `npm ci` before
-`npm run dist:mac:masdev`.
+   If this is your first time running desktop locally, be sure to run `npm ci` before
+   `npm run dist:mac:masdev`.
 
-:::
+   :::
 
-### Troubleshoot
+### Troubleshooting
 
 If you receive an error stating `You do not have permission to open the application "Bitwarden".`
 ensure the correct provisioning profile is placed in the desktop repository root.
+
+## Testing in QA
+
+Per the SDLC, QA verifies changes before they are merged into main. Currently the github CI
+workflows for building mac desktop do not create a build artifact as part of the workflow run. QA
+can obtain a build through following these steps:
+
+1. Navigate to the `Build Desktop` workflow in GHA
+2. Click the `Run workflow` dropbox
+   - select the branch in question
+   - ensure "Force distribute to TestFlight" is checked.

--- a/docs/getting-started/clients/desktop/mac/index.md
+++ b/docs/getting-started/clients/desktop/mac/index.md
@@ -89,8 +89,8 @@ ensure the correct provisioning profile is placed in the desktop repository root
 ## Testing in QA
 
 Per the SDLC, QA verifies changes before they are merged into main. Currently the GitHub CI
-workflows for building the Mac desktop client do not create a build artifact for the Mac App Store as
-part of the workflow run. QA can obtain a build through these steps:
+workflows for building the Mac desktop client do not create a build artifact for the Mac App Store
+as part of the workflow run. QA can obtain a build through these steps:
 
 1. Navigate to the `Build Desktop` workflow under the `GitHub Actions` tab.
 2. Click the `Run workflow` dropbox.

--- a/docs/getting-started/clients/desktop/mac/index.md
+++ b/docs/getting-started/clients/desktop/mac/index.md
@@ -94,5 +94,5 @@ can obtain a build through following these steps:
 
 1. Navigate to the `Build Desktop` workflow in GHA
 2. Click the `Run workflow` dropbox
-   - select the branch in question
-   - ensure "Force distribute to TestFlight" is checked.
+   - Select the branch in question
+   - Ensure "Force distribute to TestFlight" is checked

--- a/docs/getting-started/clients/desktop/mac/index.md
+++ b/docs/getting-started/clients/desktop/mac/index.md
@@ -89,7 +89,7 @@ ensure the correct provisioning profile is placed in the desktop repository root
 ## Testing in QA
 
 Per the SDLC, QA verifies changes before they are merged into main. Currently the GitHub CI
-workflows for building Mac desktop client do not create a build artifact for the Mac App Store as
+workflows for building the Mac desktop client do not create a build artifact for the Mac App Store as
 part of the workflow run. QA can obtain a build through these steps:
 
 1. Navigate to the `Build Desktop` workflow under the `GitHub Actions` tab.

--- a/docs/getting-started/clients/desktop/mac/index.md
+++ b/docs/getting-started/clients/desktop/mac/index.md
@@ -88,11 +88,11 @@ ensure the correct provisioning profile is placed in the desktop repository root
 
 ## Testing in QA
 
-Per the SDLC, QA verifies changes before they are merged into main. Currently the github CI
-workflows for building mac desktop do not create a build artifact as part of the workflow run. QA
-can obtain a build through following these steps:
+Per the SDLC, QA verifies changes before they are merged into main. Currently the GitHub CI
+workflows for building Mac desktop client do not create a build artifact for the Mac App Store as
+part of the workflow run. QA can obtain a build through these steps:
 
-1. Navigate to the `Build Desktop` workflow in GHA
-2. Click the `Run workflow` dropbox
-   - Select the branch in question
-   - Ensure "Force distribute to TestFlight" is checked
+1. Navigate to the `Build Desktop` workflow under the `GitHub Actions` tab.
+2. Click the `Run workflow` dropbox.
+   - Select the branch in question.
+   - Ensure "Force distribute to TestFlight" is checked.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

- renames the current "Testing" section to "Build", which is more accurate
- adds a new testing section that describes the how to do verification of builds

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
