### PR TITLE
(dependencies) Add note for upcoming rename of Renovate bot to Mend bot.

### DIFF
--- a/docs/contributing/dependencies/index.md
+++ b/docs/contributing/dependencies/index.md
@@ -9,6 +9,18 @@ Bitwarden uses [Renovate](https://www.mend.io/renovate/) for automating dependen
 will automatically create pull requests for dependencies on a weekly cadence. Security updates will
 generate pull requests immediately.
 
+:::note
+
+As of September 25, 2025, the Renovate bot will be renamed Mend bot. From
+[the announcement](https://github.com/renovatebot/renovate/discussions/37842):
+
+> Coming soon, the much used and well loved [Renovate GitHub app](https://github.com/apps/renovate)
+> (a.k.a. "Renovate Bot") will be getting renamed to "Mend". Commits, PRs, Issues and Comments
+> authored by the Renovate app will reflect the new name and you will see "Mend [bot]" where you
+> used to see "Renovate [bot]".
+
+:::
+
 ## Renovate configuration
 
 Renovate is configured by a `.github/renovate.json` (or `.github/renovate.json5`) file in each


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Add a note advising readers of the upcoming rename to the Renovate bot, making it easier to arrive at documentation when searching "mend", "mend bot", or "mend [bot]". The official announcement has also been included in part and linked to.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
