### PR TITLE
Revert #675 (renovate bot renaming cancelled)

### DIFF
--- a/docs/contributing/dependencies/index.md
+++ b/docs/contributing/dependencies/index.md
@@ -9,18 +9,6 @@ Bitwarden uses [Renovate](https://www.mend.io/renovate/) for automating dependen
 will automatically create pull requests for dependencies on a weekly cadence. Security updates will
 generate pull requests immediately.
 
-:::note
-
-As of September 25, 2025, the Renovate bot will be renamed Mend bot. From
-[the announcement](https://github.com/renovatebot/renovate/discussions/37842):
-
-> Coming soon, the much used and well loved [Renovate GitHub app](https://github.com/apps/renovate)
-> (a.k.a. "Renovate Bot") will be getting renamed to "Mend". Commits, PRs, Issues and Comments
-> authored by the Renovate app will reflect the new name and you will see "Mend [bot]" where you
-> used to see "Renovate [bot]".
-
-:::
-
 ## Renovate configuration
 
 Renovate is configured by a `.github/renovate.json` (or `.github/renovate.json5`) file in each


### PR DESCRIPTION
This reverts commit 3cb9d19b094214d75e1286e2965a5cf6429a9a7a.

## 🎟️ Tracking

N/A

## 📔 Objective

In an updated announcement, Mend have decided to [cancel the proposed renaming of renovate bot](https://github.com/renovatebot/renovate/discussions/37842). This PR reverts the note which was added to Dependencies notifying readers that the bot may show as "renovate [bot]" or "mend [bot]" in active automated pull requests while in transition. That transition is now not scheduled to happen.

View the original PR [here](https://github.com/bitwarden/contributing-docs/pull/675).

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
