### PR TITLE
Fix MCP naming

### DIFF
--- a/docs/contributing/ai.md
+++ b/docs/contributing/ai.md
@@ -107,7 +107,7 @@ structured, step-by-step reasoning for complex tasks.
 #### For Claude Code
 
 ```bash
-claude mcp add --scope user memory -- npx -y @modelcontextprotocol/server-sequential-thinking
+claude mcp add --scope user sequential-thinking -- npx -y @modelcontextprotocol/server-sequential-thinking
 ```
 
 #### For Claude Desktop
@@ -115,7 +115,7 @@ claude mcp add --scope user memory -- npx -y @modelcontextprotocol/server-sequen
 Edit your `~/.claude.json`, go to the `mcpServers` section and add:
 
 ```json
-"anthropic-sequential": {
+"sequential-thinking": {
    "type": "stdio",
    "command": "npx",
    "args": [


### PR DESCRIPTION
## 🎟️ Tracking

Fix for #681.

## 📔 Objective

Didn't label the MCP server name correctly. Technically doesn't matter, but good to fix.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
