### PR TITLE
Remove erroneous AI test commands, tweak language

### DIFF
--- a/docs/contributing/ai.md
+++ b/docs/contributing/ai.md
@@ -104,13 +104,13 @@ We recommend at least two be installed by everyone:
 The Sequential Thinking server enhances Claude's problem-solving capabilities by providing
 structured, step-by-step reasoning for complex tasks.
 
-#### For Claude Code
+#### Claude Code
 
 ```bash
 claude mcp add --scope user sequential-thinking -- npx -y @modelcontextprotocol/server-sequential-thinking
 ```
 
-#### For Claude Desktop
+#### Claude Desktop
 
 Edit your `~/.claude.json`, go to the `mcpServers` section and add:
 
@@ -132,13 +132,13 @@ Restart Claude Desktop to activate the server.
 The Memory server provides Claude with persistent memory capabilities, allowing it to remember
 context across sessions and maintain a knowledge graph of your projects.
 
-#### For Claude Code
+#### Claude Code
 
 ```bash
 claude mcp add --scope user memory -- npx -y @modelcontextprotocol/server-memory
 ```
 
-#### For Claude Desktop
+#### Claude Desktop
 
 Edit your `~/.claude.json`, go to the `mcpServers` section and add:
 
@@ -157,18 +157,13 @@ Restart Claude Desktop to activate the server.
 
 ### Verifying Installations
 
-#### Claude Code Verification
+#### Claude Code
 
 ```bash
-# List all configured servers
 claude mcp list
-
-# Test a specific server
-claude mcp test sequential-thinking
-claude mcp test memory
 ```
 
-#### Claude Desktop Verification
+#### Claude Desktop
 
 1. Open Claude Desktop
 2. Start a new conversation


### PR DESCRIPTION
## 🎟️ Tracking

Internal conversations.

## 📔 Objective

Found that the latest Claude Code release doesn't support test commands. Also tweaked headings for consistency.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
