### PR TITLE
[PM-23209] - MacOS KVStore information

### DIFF
--- a/docs/getting-started/business/splunk-app.md
+++ b/docs/getting-started/business/splunk-app.md
@@ -3,10 +3,17 @@
 The Bitwarden Splunk app fetches event log data from the Bitwarden Public API and makes it available
 in Splunk.
 
+While the app is available for all platforms, the splunk docker image is limited to version 9.3 on
+macOS because of a dependency on the AVX instruction set.
+
+If you are using a different platform (Windows/Linux), you should be able to run up to version 10.0
+locally. To do this, change the `image` in `dev/docker-compose.yml` to `splunk/splunk:10.0`.
+
 ## Requirements
 
-- Docker. If you're using an Apple Silicon Mac, enable _Docker Desktop_ -> _Settings_ -> _General_
-  -> _Use Rosetta for x86_64/amd64 emulation on Apple Silicon_
+- Docker
+  - If you're using an Apple Silicon Mac, enable _Docker Desktop_ -> _Settings_ -> _General_ -> _Use
+    Rosetta for x86_64/amd64 emulation on Apple Silicon_
 - Python 3.7 - 3.10
 - [Poetry][poetry]
   - Also install Poetry export plugin with `poetry self add poetry-plugin-export`


### PR DESCRIPTION
## 🎟️ Tracking
[PM-23209](https://bitwarden.atlassian.net/browse/PM-23209)

## 📔 Objective
The splunk docker image relies on mongodb which in turn relies on a specific instruction to be available on the CPU (AVX). Apple Silicon does not have this, so the splunk app won't work correctly past version 9.3 on MacOS. This adds that information to the contributing docs.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
