### PR TITLE
Update SDK documentation to KeySlotIds

### DIFF
--- a/docs/architecture/sdk/adding-functionality.md
+++ b/docs/architecture/sdk/adding-functionality.md
@@ -52,7 +52,7 @@ for details on how this works and which dependency types are available.
 ```rust
 #[derive(FromClient)]
 pub struct FoldersClient {
-    pub(crate) key_store: KeyStore<KeyIds>,
+    pub(crate) key_store: KeyStore<KeySlotIds>,
     pub(crate) api_configurations: Arc<ApiConfigurations>,
     pub(crate) repository: Option<Arc<dyn Repository<Folder>>>,
 }

--- a/docs/architecture/sdk/client-patterns.md
+++ b/docs/architecture/sdk/client-patterns.md
@@ -18,7 +18,7 @@ directly to obtain their dependencies.
 ```rust
 #[derive(FromClient)]
 pub struct FoldersClient {
-    pub(crate) key_store: KeyStore<KeyIds>,
+    pub(crate) key_store: KeyStore<KeySlotIds>,
     pub(crate) api_configurations: Arc<ApiConfigurations>,
     pub(crate) repository: Option<Arc<dyn Repository<Folder>>>,
 }
@@ -26,7 +26,7 @@ pub struct FoldersClient {
 
 Some of the available dependency types that can be extracted are:
 
-- `KeyStore<KeyIds>` — access to the cryptographic key store
+- `KeyStore<KeySlotIds>` — access to the cryptographic key store
 - `Arc<ApiConfigurations>` — HTTP API client configuration
 - `Option<Arc<dyn Repository<T>>>` — state repository for a given domain type
 


### PR DESCRIPTION

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->


With the rename done in https://github.com/bitwarden/sdk-internal/pull/955 the contributing docs need to be updated to the latest naming. 