### PR TITLE
Add link and instructions for Visual C++ build tools

### DIFF
--- a/docs/getting-started/clients/desktop/index.mdx
+++ b/docs/getting-started/clients/desktop/index.mdx
@@ -17,7 +17,10 @@ well as install the [Desktop Native dependencies](./desktop-native/index.mdx#Dep
 
 These are available as additional dependencies in the Visual Studio Installer.
 
-- Visual C++ Build tools
+- Visual C++ Build tools. The newest supported version of Visual Studio can be downloaded
+  [here](https://learn.microsoft.com/en-us/visualstudio/releases/2022/release-history#evergreen-bootstrappers),
+  use the "Community" download link for the current channel. Launch the installer and ensure the
+  workload "Desktop development with C++" is selected.
 
 </TabItem>
 <TabItem value="mac" label="macOS">


### PR DESCRIPTION
## 📔 Objective

The version of `gyp` used in `clients` is not able to detect Visual Studio 2026 installations. In order for `npm ci` to succeed in `clients`, it is necessary to have Visual Studio 2022 installed. This PR introduces a link to Visual Studio 2022 downloads, and instructions. 

## 📸 Screenshots
<img width="657" height="469" alt="Untitled" src="https://github.com/user-attachments/assets/cc9b4314-ca24-4327-bb0e-c367f63578f3" />

