### PR TITLE
Update guidance on licensing cert

### DIFF
--- a/docs/getting-started/server/guide.md
+++ b/docs/getting-started/server/guide.md
@@ -306,8 +306,17 @@ To run your local server environment as a licensed instance, you will need to do
 1. Log in to your company-issued Bitwarden account
 2. On the "Vaults" page, scroll down to the "Licensing Certificate - Dev" item
 3. View attachments and download both files
-4. Create a `~/.secrets/` folder and place the dev.cer inside
-5. Add the path to the `dev.cer` to `secrets.json` under `LicenseCertificatePath`
+4. Create a `~/.secrets/` folder and place `dev.pfx` inside
+5. Add the following under `globalSettings` in `secrets.json`, substituting your own path to
+   `dev.pfx` and the password from the "Licensing Certificate - Dev" vault item:
+
+   ```json
+   "licenseCertificatePath": "/Users/<your name>/.secrets/dev.pfx",
+   "licenseCertificatePassword": "<password from the vault item>"
+   ```
+
+6. Re-run `setup_secrets.ps1` to apply the new values to every server project — see
+   [Configure user secrets](#configure-user-secrets).
 
 :::warning
 

--- a/docs/getting-started/server/guide.md
+++ b/docs/getting-started/server/guide.md
@@ -309,8 +309,12 @@ To run your local server environment as a licensed instance, you will need to do
 4. Create a `~/.secrets/` folder and place the dev.cer inside
 5. Add the path to the `dev.cer` to `secrets.json` under `LicenseCertificatePath`
 
-:::warning Do not import the "Licensing Certificate - Dev" into your keychain. Doing so may
-compromise all TLS traffic on your development machine. :::
+:::warning
+
+Do not import the "Licensing Certificate - Dev" into your keychain. Doing so may compromise all TLS
+traffic on your development machine.
+
+:::
 
 </Bitwarden>
 

--- a/docs/getting-started/server/guide.md
+++ b/docs/getting-started/server/guide.md
@@ -305,7 +305,7 @@ To run your local server environment as a licensed instance, you will need to do
 
 1. Log in to your company-issued Bitwarden account
 2. On the "Vaults" page, scroll down to the "Licensing Certificate - Dev" item
-3. View attachments and download both files
+3. View attachments and only download `dev.pfx`
 4. Create a `~/.secrets/` folder and place `dev.pfx` inside
 5. Add the following under `globalSettings` in `secrets.json`, substituting your own path to
    `dev.pfx` and the password from the "Licensing Certificate - Dev" vault item:

--- a/docs/getting-started/server/guide.md
+++ b/docs/getting-started/server/guide.md
@@ -301,16 +301,7 @@ up-to-date. See [MSSQL Database](./database/mssql/index.md) for more information
 ## Install licensing certificate
 
 To run your local server environment as a licensed instance, you will need to download the
-`Licensing Certificate - Dev` from the shared Engineering collection and install it. This can be
-done by double-clicking on the downloaded certificate.
-
-:::note
-
-Mac users: When prompted to save the downloaded certificate and PFX file in Keychain Access be sure
-to select "Default Keychain > login" from the dropdown otherwise they will not be found when
-attempting to "Build and Run the Server".
-
-:::
+`Licensing Certificate - Dev` from the shared Engineering collection.
 
 1. Log in to your company-issued Bitwarden account
 2. On the "Vaults" page, scroll down to the "Licensing Certificate - Dev" item

--- a/docs/getting-started/server/guide.md
+++ b/docs/getting-started/server/guide.md
@@ -315,9 +315,11 @@ attempting to "Build and Run the Server".
 1. Log in to your company-issued Bitwarden account
 2. On the "Vaults" page, scroll down to the "Licensing Certificate - Dev" item
 3. View attachments and download both files
-4. Go to Keychain Access and set the dev.cer certificate to "Always Trust"
-5. The dev.pfx file will ask for a password. You can get this by clicking and opening the Licensing
-   Certificate - Dev item in the vault
+4. Create a `~/.secrets/` folder and place the dev.cer inside
+5. Add the path to the `dev.cer` to `secrets.json` under `LicenseCertificatePath`
+
+:::warning Do not import the "Licensing Certificate - Dev" into your keychain. Doing so may
+compromise all TLS traffic on your development machine. :::
 
 </Bitwarden>
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-36250

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The current contributing docs prescribe loading the licensing certificate as a root certificate into the OS keychain. This gives everyone with the root certificate - all bitwarden employees - the ability to spoof, intercept and tamper with all TLS traffic of all everyone who has this trusted root certificate in their keychain.

Instead of loading it into the keychain as a root certificate, this PR adds the ability to load it from a file, only for the specific scope of the `bitwarden/server` application, entirely eliminating this risk.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->