### PR TITLE
update docs reference dotnet 10 instead of 8

### DIFF
--- a/docs/getting-started/server/guide.md
+++ b/docs/getting-started/server/guide.md
@@ -17,7 +17,7 @@ Before you start: make sure you’ve installed the recommended
 - Docker Desktop
 - Visual Studio 2022
 - Powershell
-- [NET 8.0 SDK](https://dotnet.microsoft.com/download)
+- [.NET 10 SDK](https://dotnet.microsoft.com/download)
 - [Rust](https://www.rust-lang.org/tools/install) latest stable version - (preferably installed via
   [rustup](https://rustup.rs/))
 - Your preferred database management tool


### PR DESCRIPTION
We just upgraded to .NET SDK 10 and as I was reading the contributing docs I noticed we still reference .NET SDK 8. Figured it would be good to update this.
