### PR TITLE
docs: restore hardware key callout to top-level SSH signing tip

### DIFF
--- a/docs/contributing/commit-signing.mdx
+++ b/docs/contributing/commit-signing.mdx
@@ -27,7 +27,9 @@ GitHub supports [commit signing][github-verification] with SSH, GPG, and S/MIME.
 
 If you're unsure what to use, <strong>we recommend you create a commit signing key using SSH per
 latest security best practices </strong> (see the
-[PGP problem](https://www.latacora.com/blog/2019/07/16/the-pgp-problem/) for more details).
+[PGP problem](https://www.latacora.com/blog/2019/07/16/the-pgp-problem/) for more details). For
+maximum security, consider using a [hardware-backed SSH key](#hardware-backed-ssh-key-configuration)
+(YubiKey or other FIDO2 device) as your signing key.
 
 :::
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.slack.com/archives/GRN5AAZ6Y/p1778000211187909

## 📔 Objective

On https://github.com/bitwarden/contributing-docs/pull/672 we moved the sk-backed key recommendation out of the main tip and into a nested step. Add it back at the top level so hardware keys remain visibly ranked as the highest-security option.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
