### PR TITLE
Clarify macOS PFX certificate handling

### DIFF
--- a/docs/getting-started/server/guide.md
+++ b/docs/getting-started/server/guide.md
@@ -318,6 +318,14 @@ To run your local server environment as a licensed instance, you will need to do
 6. Re-run `setup_secrets.ps1` to apply the new values to every server project — see
    [Configure user secrets](#configure-user-secrets).
 
+:::note macOS users
+
+The `dev.pfx` file does not need to be imported into Keychain Access. If macOS reports that the
+password is invalid while opening or importing the file, leave it out of Keychain and use the
+`licenseCertificatePath` and `licenseCertificatePassword` values in `secrets.json` instead.
+
+:::
+
 :::warning
 
 Do not import the "Licensing Certificate - Dev" into your keychain. Doing so may compromise all TLS

--- a/docs/getting-started/server/troubleshooting.md
+++ b/docs/getting-started/server/troubleshooting.md
@@ -6,6 +6,17 @@ sidebar_position: 10
 
 ## macOS
 
+### PFX password rejected by Keychain Access
+
+If Keychain Access reports that the password is invalid when opening a `.pfx` file, first confirm
+that the setup instructions actually require importing the file. For example, the
+`Licensing Certificate - Dev` should be referenced from `secrets.json`, not imported into Keychain
+Access.
+
+When you are generating your own PKCS#12 file and do need to import it into Keychain Access,
+regenerate the file with a macOS-compatible PKCS#12 format. For OpenSSL 3, add the `-legacy` option
+to the `openssl pkcs12 -export` command, or regenerate the file with OpenSSL 1.1.
+
 ### AppleCFErrorCryptographicException
 
 Error:


### PR DESCRIPTION
## Summary

- Clarifies that the internal `dev.pfx` licensing certificate should be referenced from `secrets.json` rather than imported into macOS Keychain Access.
- Adds a macOS troubleshooting entry for Keychain Access rejecting a PFX password, including the OpenSSL 3 `-legacy` compatibility option for locally generated PKCS#12 files.

Fixes #178

## Checks

- `npx.cmd prettier --check docs/getting-started/server/guide.md docs/getting-started/server/troubleshooting.md`
- `npx.cmd cspell lint docs/getting-started/server/guide.md docs/getting-started/server/troubleshooting.md`
- `npm.cmd run build`

## Notes

The full `npm.cmd run lint` command currently reports existing formatting warnings across many files in this Windows checkout. The two changed files pass targeted Prettier checks.
