### PR TITLE
[PM-38553] Key Connector on .NET 10

### DIFF
--- a/docs/getting-started/business/key-connector.mdx
+++ b/docs/getting-started/business/key-connector.mdx
@@ -17,6 +17,8 @@ understand how it works.
 - A [local development server](../server/guide.md), running in the
   [self-hosted configuration](../server/self-hosted/index.mdx)
 - An enterprise organization with [Single Sign-On](../server/sso/index.md) configured
+- [Web vault](../clients/web-vault) running locally
+- [.NET 10.0 SDK](https://www.microsoft.com/net/download/core)
 
 </Bitwarden>
 
@@ -24,73 +26,17 @@ understand how it works.
 
 - A [local development server](../server/guide.md) running in the self-hosted configuration
 - An enterprise organization with SSO configured
+- [Web vault](../clients/web-vault) running locally
+- [.NET 10.0 SDK](https://www.microsoft.com/net/download/core)
 
 </Community>
-
-- [Web vault](../clients/web-vault) running locally
-- [.NET 8.0 SDK](https://www.microsoft.com/net/download/core)
-
-### macOS
-
-macOS requires updated SSL libraries, otherwise you will receive the error "No usable version of
-libssl was found".
-
-<Tabs>
-<TabItem value="intel" label="Intel" default>
-
-1. Install [Homebrew](https://brew.sh/)
-2. Install the OpenSSL package:
-   ```bash
-   brew install openssl
-   ```
-3. Set the required environment variables to point to the OpenSSL libraries:
-   ```bash
-   echo 'DYLD_LIBRARY_PATH="/usr/local/opt/openssl@1.1/lib"' >> ~/.zshrc
-   ```
-4. If you are running the Key Connector from a terminal, restart your terminal to make sure the
-   updated `.zshrc` settings are applied
-
-</TabItem>
-<TabItem value="arm" label="ARM">
-
-Given that the Key Connector project is based on NET 5 then we need to use the x86_64 version of
-OpenSSL, thus installing x86_64 packages using Homebrew (a guide with several approaches can be
-found
-[here](https://www.wisdomgeek.com/development/installing-intel-based-packages-using-homebrew-on-the-m1-mac/)).
-
-1. Install Rosetta
-   ```bash
-   softwareupdate --install-rosetta
-   ```
-2. Set your terminal to Open using Rosetta (create a duplicate of the terminal application -> Go to
-   Get Info -> check Open using Rosetta).
-3. Install [Homebrew](https://brew.sh/)
-
-   3.a This should gives us a Homebrew living in `/usr/local` but if it doesn't work prepend
-   `arch -x86_64` before the Homebrew installation command.
-
-4. Install the OpenSSL package using the x86_64 Homebrew:
-   ```bash
-   arch -x86_64 /usr/local/homebrew/bin/brew install openssl
-   ```
-5. Set the required environment variables to point to the OpenSSL libraries:
-   ```bash
-   echo 'export DYLD_LIBRARY_PATH="/usr/local/opt/openssl@1.1/lib"' >> ~/.zshrc
-   ```
-6. If you are running the Key Connector from a terminal, restart your terminal to make sure the
-   updated `.zshrc` settings are applied or run
-   ```bash
-   source ~/.zshrc
-   ```
-
-</TabItem>
-</Tabs>
 
 ## Setup and configuration
 
 1. Clone the repository:
    ```bash
    git clone https://github.com/bitwarden/key-connector.git
+   cd key-connector
    ```
 
 ### Configure keys and user secrets
@@ -155,7 +101,8 @@ If you need help setting user secrets, see the
    - Single Sign-On:
      - Member Decryption Option: Key Connector
 
-     - Key Connector URL: `http://localhost:5000`
+     - Key Connector URL: `https://localhost:8081/key-connector` (this uses
+       `https://localhost:8081`, the default local web vault URL)
 
 ## Running and Debugging
 
@@ -176,17 +123,8 @@ Run the following command from the repository root:
 dotnet run --project src/KeyConnector --configuration Development
 ```
 
-:::note
-
-If running on ARM based Mac you may need to use `/usr/local/share/dotnet/x64/dotnet`
-
-```bash
-/usr/local/share/dotnet/x64/dotnet run --project src/KeyConnector --configuration Development
-```
-
-:::
-
-The `--configuration` flag is required for macOS to use the right SSL libraries.
+The `--configuration Development` flag is required so Key Connector loads
+`appsettings.Development.json`, which resolves the correct local web vault and Identity server URIs.
 
    </TabItem>
 </Tabs>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38553

## 📔 Objective

Update Key Connector to .NET 10:
- Changed `.NET 8.0 SDK` to `.NET 10.0 SDK`
- Removed the entire "macOS" section - it was outdated, now .NET 10 ships on arm64 arch and does not require openssl steps
- Removed the macOs ARM dotnet path note in the "Running and Debugging" -> "CLI" tab - not necessary, since setup now uniformly says .NET 10 SDK
- Updated the Key Connector URL - since it default to `<web-vault-url>/key-connector` in web vault, when configuring org SSO with Key Connector url.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
