### PR TITLE
Fix ADR typo

### DIFF
--- a/docs/architecture/adr/0029-angular-signals.md
+++ b/docs/architecture/adr/0029-angular-signals.md
@@ -5,7 +5,7 @@ date: 2025-11-24
 tags: [clients, angular]
 ---
 
-# 0028 - Adopt Angular Signals for Component State
+# 0029 - Adopt Angular Signals for Component State
 
 <AdrTable frontMatter={frontMatter}></AdrTable>
 


### PR DESCRIPTION
## 🎟️ Tracking

Noticed while writing another ADR.

## 📔 Objective

An ADR headline was off by one number.
