### PR TITLE
docs: mark ADRs 0031 and 0032 as accepted

### DIFF
--- a/docs/architecture/adr/0031-adopt-minimal-apis.md
+++ b/docs/architecture/adr/0031-adopt-minimal-apis.md
@@ -1,6 +1,6 @@
 ---
 adr: "0031"
-status: "Proposed"
+status: Accepted
 date: 2026-06-23
 tags: [server]
 ---

--- a/docs/architecture/adr/0032-break-up-core.md
+++ b/docs/architecture/adr/0032-break-up-core.md
@@ -1,6 +1,6 @@
 ---
 adr: "0032"
-status: "Proposed"
+status: Accepted
 date: 2026-06-25
 tags: [server]
 ---


### PR DESCRIPTION
## 🎟️ Tracking

Discussed at Architecture Council.

## 📔 Objective

Flip the status of two server ADRs from Proposed to Accepted now that they've been signed off:

- ADR 0031 — Adopt minimal APIs
- ADR 0032 — Break up the Core project

Frontmatter-only change; the ADR content is unchanged.