### PR TITLE
Bump node and npm version requirement for clients

### DIFF
--- a/docs/getting-started/tools/index.md
+++ b/docs/getting-started/tools/index.md
@@ -35,8 +35,8 @@ of your local development environment.
   development environments
 - [PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-macos)
   (available via Homebrew: `brew install powershell`)
-- [NodeJS](https://nodejs.org/) v22 (preferably using a [node version manager][nvm])
-- [NPM](https://www.npmjs.com/) v10 (included with Node)
+- [NodeJS](https://nodejs.org/) v24 (preferably using a [node version manager][nvm])
+- [NPM](https://www.npmjs.com/) v11 (included with Node)
 - [Rust](https://www.rust-lang.org/tools/install) latest stable version - (preferably installed via
   [rustup](https://rustup.rs/))
 - [Git](https://git-scm.com)


### PR DESCRIPTION
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
With https://github.com/bitwarden/clients/pull/20400 we bumped the clients-repo to use Node 24 and npm 11 and this PR updates our tool requirements here.
