### PR TITLE
0035 - Taxonomy for AI skills, prompts, and agents

### DIFF
--- a/custom-words.txt
+++ b/custom-words.txt
@@ -35,6 +35,7 @@ Hyperscale
 iframes
 inet
 ingestibility
+inlines
 initialisms
 IntelliJ
 Iterm

--- a/docs/architecture/adr/0035-adopt-ai-plugin-taxonomy.md
+++ b/docs/architecture/adr/0035-adopt-ai-plugin-taxonomy.md
@@ -1,0 +1,209 @@
+---
+adr: "0035"
+status: Proposed
+date: 2026-08-21
+tags: [clients, mobile, server, sdk]
+---
+
+# 0035 - Adopt AI plugin taxonomy
+
+<AdrTable frontMatter={frontMatter}></AdrTable>
+
+## Context and problem statement
+
+The `bitwarden/ai-plugins` marketplace publishes 17 plugins holding 59 skills, 7 agents, and 10
+commands. There is no reliable way to decide which plugin a new skill belongs in, and the cost shows
+up as duplication and churn rather than as an argument anyone wins.
+
+The marketplace's `CONTRIBUTING.md` defines three plugin families: Persona, Tool Integration, and
+Utility. Six of the 17 plugins fit none of them cleanly. Four have no family at all
+(`bitwarden-delivery-tools`, `bitwarden-planning-tools`, `bitwarden-design-tools`,
+`bitwarden-testing-tools`), and two fit only on a technicality: `bitwarden-code-review` is named for
+an activity rather than a role, and `bitwarden-devops-engineer` is named for a role but ships no
+agent and nothing but GitHub Actions skills. Those six are exactly the plugins whose contents are
+hard to predict from their names. A family of domain skill libraries exists in practice but is
+undocumented, so it has no membership test, and `bitwarden-delivery-tools` became the default home
+for anything skill-shaped that was not a persona. It now holds git mechanics, organizational
+process, architectural judgment, and fleet automation behind a single name.
+
+The absence of a rule is measurable in the tree:
+
+- `architecting-solutions` has moved between plugins twice, and its `SKILL.md` inlines an ADR lookup
+  procedure that duplicates the `consulting-adrs` skill sitting in a different plugin.
+- `reviewing-dependency-changes` and `reviewing-dependencies` live in different plugins and each
+  spends prose defining its scope against the other.
+- Ten skills describing one process, the Software Initiative Funnel, are split across three plugins,
+  producing thirteen cross-plugin references that exist only because the skills are separated.
+- Feature-flag guidance was duplicated across two persona plugins and had to be consolidated, which
+  is what first surfaced this problem.
+
+A second requirement constrains any fix: the marketplace has to deliver tools according to a
+person's role, and a designer should not receive commit conventions or implementation planning. Many
+skills legitimately serve several roles at once. Those two goals conflict if there is only one layer
+of plugins. Grouping by role duplicates shared skills and gives them no single home; grouping only
+by domain leaves a person with no way to install the set their job needs.
+
+## Considered options
+
+- **Status quo:** three families that do not cover a third of the marketplace, and placement settled
+  case by case in PR review.
+- **Role plugins with deliberate duplication:** one plugin per job function, and a skill serving two
+  roles is copied into both. This is the model Anthropic uses in its own `knowledge-work-plugins`
+  library.
+- **Capability plugins only:** one home per skill, named by domain, with no role-level packaging.
+- **Two layers, capability plugins plus role bundles:** skills live once in a domain-named plugin,
+  and roles are expressed as dependency-only bundle plugins that compose them.
+
+## Decision outcome
+
+Chosen option: **two layers, capability plugins plus role bundles**. The rules at adoption:
+
+1. **A capability plugin holds skills and agents.** Every skill has exactly one home. It is named
+   for a domain, never for a job title, a seniority level, or a lifecycle phase.
+2. **A role bundle holds nothing but a name, a description, and dependencies.** No skills, no
+   agents, no commands. It is what a person installs, and it is named for the role.
+3. **Placement therefore ranges only over capability plugins**, because a bundle cannot hold a
+   skill. A skill serving three roles lives once and appears in three bundles.
+4. **Placement is decided in order:** repo-specific knowledge stays in that repo's `.claude/`; a
+   skill dispatched only by a sibling stays with its consumer; knowledge that would transfer
+   unchanged to another company using the same vendor product belongs to that vendor's integration
+   plugin; everything else is named for the artifact or practice it acts on.
+5. **A plugin description enumerates its skills**, which makes the boundary self-enforcing at review
+   time. A skill that does not fit the enumeration either forces a deliberate description change or
+   goes elsewhere.
+
+```mermaid
+flowchart LR
+    Skill["Skill or agent"] -->|lives once in| Cap["Capability plugin<br/>named for a domain"]
+    Cap -->|composed via dependencies into| Bundle["Role bundle<br/>name + description + dependencies, nothing else"]
+    Bundle -->|installed by| Person["Person"]
+```
+
+> _Perspective: Council reviewers ratifying the model. What separates a capability plugin from a
+> role bundle, and how a person ends up with either. System context level. Omits concrete plugin
+> names, covered below._
+
+Rule 4's ordering is itself a decision procedure, not just a sentence:
+
+```mermaid
+flowchart TD
+    A["New skill"] --> B{"Repo-specific?"}
+    B -->|yes| B1["Stays in that repo's .claude/"]
+    B -->|no| C{"Dispatched only by one sibling skill?"}
+    C -->|yes| C1["Stays with its consumer"]
+    C -->|no| D{"Transfers unchanged to another company<br/>on the same vendor product?"}
+    D -->|yes| D1["That vendor's integration plugin"]
+    D -->|no| E["Named for the artifact or practice it acts on"]
+```
+
+> _Perspective: A contributor placing a new skill. The four-branch test rule 4 states in prose,
+> walked in order. Omits the plugin-description self-check in rule 5, which runs after this tree
+> lands on an answer._
+
+Bundles use the plugin manifest's `dependencies` array, which Claude Code documents for exactly this
+purpose: a manifest consisting of only dependencies packages a curated set behind one install, and
+bundles can be pushed org-wide through managed settings.
+
+Cross-plugin dependencies are accepted at both layers, bounded by two rules. The graph stays
+shallow, ideally one level below a bundle, and every capability-to-capability edge names the
+specific skill that composes across it. An edge that cannot name one is deleted.
+`bitwarden-atlassian-tools` remains a soft dependency everywhere because it ships an MCP server that
+prompts for credentials, and a declared edge would force that prompt on every member of the roles
+that depend on it.
+
+```mermaid
+flowchart LR
+    crt["code-review-tools"] --> st["security-tools"]
+    at["architecture-tools"] --> st
+    it["initiative-tools"] --> at
+    bt["breakdown-tools"] --> at
+    bt --> st
+    bt --> cot["contribution-tools"]
+    it -. soft .-> atl["atlassian-tools"]
+    bt -. soft .-> atl
+```
+
+> _Perspective: Council reviewers assessing how deep the graph runs. Every declared
+> capability-to-capability edge in the marketplace, and how many hops deep it goes. Container level.
+> Omits the 9 capability plugins with no outgoing edges and all 8 role bundles, which attach as
+> leaves below this graph._
+
+The operational detail lives in the marketplace repository rather than here: the exhaustive mapping
+of which skill moves where, the rename ledger, and the migration sequencing. This ADR is superseded
+only if the two-layer model itself changes.
+
+A running implementation of this model is at
+[github.com/SaintPatrck/bitwarden-ai-plugins](https://github.com/SaintPatrck/bitwarden-ai-plugins).
+
+### Positive consequences
+
+- "Which plugin does this skill go in" has one answer, and the answer set excludes every role-named
+  plugin by construction.
+- Institutional knowledge stays single-sourced, so an ADR catalog reference or a funnel phase gate
+  cannot drift between copies.
+- A role installs one plugin and receives a scoped set. A designer gets the design toolkit and
+  nothing from the engineering stack.
+
+  ```mermaid
+  flowchart TB
+      subgraph SWE["bitwarden-software-engineer declares 3"]
+          direction LR
+          ct["contribution-tools"]
+          crt["code-review-tools"]
+          tt["testing-tools"]
+      end
+      crt -->|hard-abort dependency| st["security-tools"]
+
+      subgraph DES["bitwarden-designer declares 1"]
+          dt["design-tools"]
+      end
+  ```
+
+  > _Perspective: Council reviewers weighing the scoped-install claim. What two representative
+  > bundles actually resolve to at install time, contrasted side by side. Component level. Omits
+  > the other six bundles, which resolve by the same pattern._
+
+- Consolidating the funnel skills into one plugin converts thirteen cross-plugin references into
+  intra-plugin calls, and co-locating `consulting-adrs` with `architecting-solutions` makes the
+  duplicated ADR procedure removable.
+
+### Negative consequences
+
+- The model depends on plugin dependencies, which Anthropic documents in depth but does not use once
+  across either of its own plugin libraries. Bitwarden would be an early adopter of that machinery,
+  and its four failure modes each disable the dependent plugin until resolved.
+- Marketplace entries grow from 17 to 22. The count rises even though ambiguity falls, because only
+  14 of the 22 can hold a skill.
+- Migration spans several pull requests, each carrying a version bump in four places and a changelog
+  entry, and three plugins need rename entries so existing installs migrate cleanly.
+- Duplication becomes harder rather than impossible. A team that wants a private copy of a skill now
+  has to argue for it, which is the intent, but it is friction.
+
+### Plan
+
+Follow-up work in the marketplace repository, sequenced so no step depends on a later one:
+
+```mermaid
+flowchart LR
+    P0["0 · No renames<br/>delete phantoms, rewrite descriptions"] --> P1["1 · Free rename<br/>planning-tools → architecture-tools"]
+    P1 --> P2["2 · Make dependencies real<br/>README prose → declared edges"]
+    P2 --> P3["3 · Consolidate<br/>funnel skills, design pair"]
+    P3 --> P4["4 · Hollow role plugins into bundles"]
+```
+
+> _Perspective: Whoever sequences the migration PRs. The five phases below, in the order each
+> depends on the last. Roadmap level. Omits per-plugin task detail, which lives in the marketplace
+> repository's own tracking._
+
+- The `CONTRIBUTING.md` plugin families are rewritten against this decision. Tool Integration
+  becomes the platform family, Utility becomes the toolchain family, and Persona is redefined as a
+  role bundle that holds no skills.
+- Plugin descriptions are rewritten to enumerate their skills, and the marketplace catalog is
+  grouped by layer.
+- Validation is added to CI so that every plugin-qualified reference, every `Skill()` grant, and
+  every declared dependency resolves to something real, alongside the lexical invariants the
+  marketplace currently lacks.
+- The capability consolidations land one plugin identity per pull request, beginning with the
+  planning plugin that has not yet shipped and can be renamed at no cost.
+- The role plugins are hollowed into bundles once their skills have moved, and a QA bundle is added
+  for the one role with no plugin today.

--- a/docs/architecture/adr/0035-adopt-ai-plugin-taxonomy.md
+++ b/docs/architecture/adr/0035-adopt-ai-plugin-taxonomy.md
@@ -160,8 +160,8 @@ A running implementation of this model is at
   ```
 
   > _Perspective: Council reviewers weighing the scoped-install claim. What two representative
-  > bundles actually resolve to at install time, contrasted side by side. Component level. Omits
-  > the other six bundles, which resolve by the same pattern._
+  > bundles actually resolve to at install time, contrasted side by side. Component level. Omits the
+  > other six bundles, which resolve by the same pattern._
 
 - Consolidating the funnel skills into one plugin converts thirteen cross-plugin references into
   intra-plugin calls, and co-locating `consulting-adrs` with `architecting-solutions` makes the

--- a/docs/architecture/adr/0035-adopt-ai-plugin-taxonomy.md
+++ b/docs/architecture/adr/0035-adopt-ai-plugin-taxonomy.md
@@ -5,51 +5,47 @@ date: 2026-08-21
 tags: [clients, mobile, server, sdk]
 ---
 
-# 0035 - Adopt AI plugin taxonomy
+# 0035 - Adopt a taxonomy for AI skills, prompts, and agents
 
 <AdrTable frontMatter={frontMatter}></AdrTable>
 
 ## Context and problem statement
 
-The `bitwarden/ai-plugins` marketplace publishes 17 plugins holding 59 skills, 7 agents, and 10
-commands. There is no reliable way to decide which plugin a new skill belongs in, and the cost shows
-up as duplication and churn rather than as an argument anyone wins.
+The AI plugin marketplace publishes dozens of plugins holding many skills, agents, and commands.
+There is no reliable way to decide which plugin a new skill belongs in, and the cost shows up as
+duplication and churn rather than as an argument anyone wins.
 
-The marketplace's `CONTRIBUTING.md` defines three plugin families: Persona, Tool Integration, and
-Utility. Six of the 17 plugins fit none of them cleanly. Four have no family at all
-(`bitwarden-delivery-tools`, `bitwarden-planning-tools`, `bitwarden-design-tools`,
-`bitwarden-testing-tools`), and two fit only on a technicality: `bitwarden-code-review` is named for
-an activity rather than a role, and `bitwarden-devops-engineer` is named for a role but ships no
-agent and nothing but GitHub Actions skills. Those six are exactly the plugins whose contents are
-hard to predict from their names. A family of domain skill libraries exists in practice but is
-undocumented, so it has no membership test, and `bitwarden-delivery-tools` became the default home
-for anything skill-shaped that was not a persona. It now holds git mechanics, organizational
-process, architectural judgment, and fleet automation behind a single name.
+The marketplace's contribution guide defines a small number of plugin families. A meaningful
+fraction of plugins fit none of them cleanly: several have no family at all, and others fit only on
+a technicality — named for an activity rather than a role, or named for a role but shipping no agent
+and nothing but generic skills. Those are exactly the plugins whose contents are hardest to predict
+from their names. A family of domain skill libraries exists in practice but is undocumented, so it
+has no membership test, and one plugin became the default home for anything skill-shaped that was
+not a persona. It now holds several unrelated concerns behind a single name.
 
 The absence of a rule is measurable in the tree:
 
-- `architecting-solutions` has moved between plugins twice, and its `SKILL.md` inlines an ADR lookup
-  procedure that duplicates the `consulting-adrs` skill sitting in a different plugin.
-- `reviewing-dependency-changes` and `reviewing-dependencies` live in different plugins and each
-  spends prose defining its scope against the other.
-- Ten skills describing one process, the Software Initiative Funnel, are split across three plugins,
-  producing thirteen cross-plugin references that exist only because the skills are separated.
-- Feature-flag guidance was duplicated across two persona plugins and had to be consolidated, which
-  is what first surfaced this problem.
+- A skill has moved between plugins more than once, and its own documentation inlines a procedure
+  that duplicates a separate skill sitting in a different plugin.
+- Two skills covering closely related scopes live in different plugins, and each spends prose
+  defining its boundary against the other.
+- A single process spanning many steps is split across several plugins, producing many cross-plugin
+  references that exist only because the steps were separated.
+- Guidance was duplicated across two persona plugins and had to be consolidated, which is what first
+  surfaced this problem.
 
 A second requirement constrains any fix: the marketplace has to deliver tools according to a
-person's role, and a designer should not receive commit conventions or implementation planning. Many
-skills legitimately serve several roles at once. Those two goals conflict if there is only one layer
-of plugins. Grouping by role duplicates shared skills and gives them no single home; grouping only
-by domain leaves a person with no way to install the set their job needs.
+person's role, and someone in one role should not receive guidance meant for another. Many skills
+legitimately serve several roles at once. Those two goals conflict if there is only one layer of
+plugins. Grouping by role duplicates shared skills and gives them no single home; grouping only by
+domain leaves a person with no way to install the set their job needs.
 
 ## Considered options
 
-- **Status quo:** three families that do not cover a third of the marketplace, and placement settled
-  case by case in PR review.
+- **Status quo:** a small number of families that don't cover a meaningful share of the marketplace,
+  and placement settled case by case in review.
 - **Role plugins with deliberate duplication:** one plugin per job function, and a skill serving two
-  roles is copied into both. This is the model Anthropic uses in its own `knowledge-work-plugins`
-  library.
+  roles is copied into both. Other organizations use this model for their own AI plugin libraries.
 - **Capability plugins only:** one home per skill, named by domain, with no role-level packaging.
 - **Two layers, capability plugins plus role bundles:** skills live once in a domain-named plugin,
   and roles are expressed as dependency-only bundle plugins that compose them.
@@ -64,10 +60,10 @@ Chosen option: **two layers, capability plugins plus role bundles**. The rules a
    agents, no commands. It is what a person installs, and it is named for the role.
 3. **Placement therefore ranges only over capability plugins**, because a bundle cannot hold a
    skill. A skill serving three roles lives once and appears in three bundles.
-4. **Placement is decided in order:** repo-specific knowledge stays in that repo's `.claude/`; a
-   skill dispatched only by a sibling stays with its consumer; knowledge that would transfer
-   unchanged to another company using the same vendor product belongs to that vendor's integration
-   plugin; everything else is named for the artifact or practice it acts on.
+4. **Placement is decided in order:** repo-specific knowledge stays in that repo's local
+   configuration; a skill dispatched only by a sibling stays with its consumer; knowledge that would
+   transfer unchanged to another company using the same vendor product belongs to that vendor's
+   integration plugin; everything else is named for the artifact or practice it acts on.
 5. **A plugin description enumerates its skills**, which makes the boundary self-enforcing at review
    time. A skill that does not fit the enumeration either forces a deliberate description change or
    goes elsewhere.
@@ -88,7 +84,7 @@ Rule 4's ordering is itself a decision procedure, not just a sentence:
 ```mermaid
 flowchart TD
     A["New skill"] --> B{"Repo-specific?"}
-    B -->|yes| B1["Stays in that repo's .claude/"]
+    B -->|yes| B1["Stays in that repo's local configuration"]
     B -->|no| C{"Dispatched only by one sibling skill?"}
     C -->|yes| C1["Stays with its consumer"]
     C -->|no| D{"Transfers unchanged to another company<br/>on the same vendor product?"}
@@ -100,33 +96,32 @@ flowchart TD
 > walked in order. Omits the plugin-description self-check in rule 5, which runs after this tree
 > lands on an answer._
 
-Bundles use the plugin manifest's `dependencies` array, which Claude Code documents for exactly this
+Bundles use the plugin manifest's dependencies array, which the platform documents for exactly this
 purpose: a manifest consisting of only dependencies packages a curated set behind one install, and
 bundles can be pushed org-wide through managed settings.
 
 Cross-plugin dependencies are accepted at both layers, bounded by two rules. The graph stays
 shallow, ideally one level below a bundle, and every capability-to-capability edge names the
-specific skill that composes across it. An edge that cannot name one is deleted.
-`bitwarden-atlassian-tools` remains a soft dependency everywhere because it ships an MCP server that
-prompts for credentials, and a declared edge would force that prompt on every member of the roles
-that depend on it.
+specific skill that composes across it. An edge that cannot name one is deleted. One integration
+plugin remains a soft dependency everywhere because it ships a connection to an external service
+that prompts for credentials, and a declared edge would force that prompt on every member of the
+roles that depend on it.
 
 ```mermaid
 flowchart LR
-    crt["code-review-tools"] --> st["security-tools"]
-    at["architecture-tools"] --> st
-    it["initiative-tools"] --> at
-    bt["breakdown-tools"] --> at
-    bt --> st
-    bt --> cot["contribution-tools"]
-    it -. soft .-> atl["atlassian-tools"]
-    bt -. soft .-> atl
+    c1["Capability A"] --> c2["Capability B"]
+    c3["Capability C"] --> c2
+    c4["Capability D"] --> c3
+    c5["Capability E"] --> c3
+    c5 --> c6["Capability F"]
+    c4 -. soft .-> c7["Integration capability"]
+    c5 -. soft .-> c7
 ```
 
 > _Perspective: Council reviewers assessing how deep the graph runs. Every declared
 > capability-to-capability edge in the marketplace, and how many hops deep it goes. Container level.
-> Omits the 9 capability plugins with no outgoing edges and all 8 role bundles, which attach as
-> leaves below this graph._
+> Omits the capability plugins with no outgoing edges and all role bundles, which attach as leaves
+> below this graph._
 
 The operational detail lives in the marketplace repository rather than here: the exhaustive mapping
 of which skill moves where, the rename ledger, and the migration sequencing. This ADR is superseded
@@ -136,43 +131,43 @@ only if the two-layer model itself changes.
 
 - "Which plugin does this skill go in" has one answer, and the answer set excludes every role-named
   plugin by construction.
-- Institutional knowledge stays single-sourced, so an ADR catalog reference or a funnel phase gate
-  cannot drift between copies.
-- A role installs one plugin and receives a scoped set. A designer gets the design toolkit and
-  nothing from the engineering stack.
+- Institutional knowledge stays single-sourced, so a reference or a process-phase gate cannot drift
+  between copies.
+- A role installs one plugin and receives a scoped set. Someone in one role gets their toolkit and
+  nothing from an unrelated stack.
 
   ```mermaid
   flowchart TB
-      subgraph SWE["bitwarden-software-engineer declares 3"]
+      subgraph R1["Role bundle A declares 3"]
           direction LR
-          ct["contribution-tools"]
-          crt["code-review-tools"]
-          tt["testing-tools"]
+          cap1["Capability"]
+          cap2["Capability"]
+          cap3["Capability"]
       end
-      crt -->|hard-abort dependency| st["security-tools"]
+      cap2 -->|hard-abort dependency| st["Shared capability"]
 
-      subgraph DES["bitwarden-designer declares 1"]
-          dt["design-tools"]
+      subgraph R2["Role bundle B declares 1"]
+          cap4["Capability"]
       end
   ```
 
   > _Perspective: Council reviewers weighing the scoped-install claim. What two representative
   > bundles actually resolve to at install time, contrasted side by side. Component level. Omits the
-  > other six bundles, which resolve by the same pattern._
+  > other bundles, which resolve by the same pattern._
 
-- Consolidating the funnel skills into one plugin converts thirteen cross-plugin references into
-  intra-plugin calls, and co-locating `consulting-adrs` with `architecting-solutions` makes the
-  duplicated ADR procedure removable.
+- Consolidating a multi-step process's skills into one plugin converts many cross-plugin references
+  into intra-plugin calls, and co-locating a lookup skill with the skill that needs it makes a
+  duplicated procedure removable.
 
 ### Negative consequences
 
-- The model depends on plugin dependencies, which Anthropic documents in depth but does not use once
-  across either of its own plugin libraries. Bitwarden would be an early adopter of that machinery,
-  and its four failure modes each disable the dependent plugin until resolved.
-- Marketplace entries grow from 17 to 22. The count rises even though ambiguity falls, because only
-  14 of the 22 can hold a skill.
-- Migration spans several pull requests, each carrying a version bump in four places and a changelog
-  entry, and three plugins need rename entries so existing installs migrate cleanly.
+- The model depends on plugin dependencies, a platform feature that is documented in depth but not
+  used at scale elsewhere yet. Bitwarden would be an early adopter of that machinery, and its
+  failure modes each disable the dependent plugin until resolved.
+- Marketplace entries grow in count even though ambiguity falls, because only some of the resulting
+  entries can hold a skill.
+- Migration spans several pull requests, each carrying a version bump and a changelog entry, and
+  some plugins need rename entries so existing installs migrate cleanly.
 - Duplication becomes harder rather than impossible. A team that wants a private copy of a skill now
   has to argue for it, which is the intent, but it is friction.
 
@@ -182,9 +177,9 @@ Follow-up work in the marketplace repository, sequenced so no step depends on a 
 
 ```mermaid
 flowchart LR
-    P0["0 · No renames<br/>delete phantoms, rewrite descriptions"] --> P1["1 · Free rename<br/>planning-tools → architecture-tools"]
+    P0["0 · No renames<br/>delete phantoms, rewrite descriptions"] --> P1["1 · Free rename<br/>rename a plugin to match its actual domain"]
     P1 --> P2["2 · Make dependencies real<br/>README prose → declared edges"]
-    P2 --> P3["3 · Consolidate<br/>funnel skills, design pair"]
+    P2 --> P3["3 · Consolidate<br/>related skills, related pairs"]
     P3 --> P4["4 · Hollow role plugins into bundles"]
 ```
 
@@ -192,15 +187,13 @@ flowchart LR
 > depends on the last. Roadmap level. Omits per-plugin task detail, which lives in the marketplace
 > repository's own tracking._
 
-- The `CONTRIBUTING.md` plugin families are rewritten against this decision. Tool Integration
-  becomes the platform family, Utility becomes the toolchain family, and Persona is redefined as a
-  role bundle that holds no skills.
-- Plugin descriptions are rewritten to enumerate their skills, and the marketplace catalog is
-  grouped by layer.
-- Validation is added to CI so that every plugin-qualified reference, every `Skill()` grant, and
-  every declared dependency resolves to something real, alongside the lexical invariants the
-  marketplace currently lacks.
-- The capability consolidations land one plugin identity per pull request, beginning with the
-  planning plugin that has not yet shipped and can be renamed at no cost.
-- The role plugins are hollowed into bundles once their skills have moved, and a QA bundle is added
-  for the one role with no plugin today.
+- The contribution guide's plugin families are rewritten against this decision, and the marketplace
+  catalog is regrouped by layer.
+- Plugin descriptions are rewritten to enumerate their skills.
+- Validation is added to CI so that every plugin-qualified reference, every skill grant, and every
+  declared dependency resolves to something real, alongside the lexical invariants the marketplace
+  currently lacks.
+- The capability consolidations land one plugin identity per pull request, beginning with the plugin
+  that has not yet shipped and can be renamed at no cost.
+- The role plugins are hollowed into bundles once their skills have moved, and a bundle is added for
+  the one role with no plugin today.

--- a/docs/architecture/adr/0035-adopt-ai-plugin-taxonomy.md
+++ b/docs/architecture/adr/0035-adopt-ai-plugin-taxonomy.md
@@ -132,9 +132,6 @@ The operational detail lives in the marketplace repository rather than here: the
 of which skill moves where, the rename ledger, and the migration sequencing. This ADR is superseded
 only if the two-layer model itself changes.
 
-A running implementation of this model is at
-[github.com/SaintPatrck/bitwarden-ai-plugins](https://github.com/SaintPatrck/bitwarden-ai-plugins).
-
 ### Positive consequences
 
 - "Which plugin does this skill go in" has one answer, and the answer set excludes every role-named

--- a/docs/architecture/adr/0035-adopt-ai-plugin-taxonomy.md
+++ b/docs/architecture/adr/0035-adopt-ai-plugin-taxonomy.md
@@ -101,9 +101,9 @@ flowchart TD
 > walked in order. Omits the plugin-description self-check in rule 5, which runs after this tree
 > lands on an answer._
 
-The vendor branch has a reciprocal. A component driving one workflow through a vendor surface
-composes that vendor's integration plugin and hands it content, so the conventions for using the
-product stay in one place and the specialized component carries none of them.
+A component driving one workflow through a vendor surface composes that vendor's integration plugin
+and hands it content, so the conventions for using the product stay in one place and the specialized
+component carries none of them.
 
 A third kind of entry sits outside both layers. An **external entry** names a third-party repository
 and a commit. Its files stay upstream, so the pinned commit is the whole of its security boundary.

--- a/docs/architecture/adr/0035-adopt-ai-plugin-taxonomy.md
+++ b/docs/architecture/adr/0035-adopt-ai-plugin-taxonomy.md
@@ -56,27 +56,29 @@ skill and leaves the joining problem where it is.
 
 Chosen option: **two layers, capability plugins plus role bundles**. The rules at adoption:
 
-1. **A capability plugin holds skills and agents.** Every skill has exactly one home. It is named
-   for what its skills act on, meaning an artifact, a practice, or an integration surface, never for
-   a job title, a seniority level, or a lifecycle phase.
-2. **A role bundle holds nothing but a name, a description, and dependencies.** No skills, no
-   agents, no commands. CI enforces it. It is what a person installs, and it is named for the role.
+1. **A capability plugin carries components.** Whatever kinds of component the platform supports,
+   this is what holds them, and every component has exactly one home. It is named for what its
+   components act on, meaning an artifact, a practice, or an integration surface, never for a job
+   title, a seniority level, or a lifecycle phase.
+2. **A role bundle holds nothing but a name, a description, and dependencies.** No components of any
+   kind. CI enforces it. It is what a person installs, and it is named for the role.
 3. **Placement therefore ranges only over capability plugins**, because a bundle holds nothing. A
-   skill serving three roles lives once and appears in three bundles.
-4. **Placement is decided in order,** for a skill and an agent alike: repo-specific knowledge stays
-   in that repo's local configuration, where repo-specific means unusable outside that repo's
-   codebase; an artifact dispatched only by a sibling stays with its consumer; knowledge that would
-   transfer unchanged to another company using the same vendor product belongs to that vendor's
-   integration plugin; everything else is named for the artifact or practice it acts on.
-5. **A plugin description enumerates its skills**, which makes the boundary self-enforcing at review
-   time. A skill that does not fit the enumeration either forces a deliberate description change or
-   goes elsewhere.
+   component serving three roles lives once and appears in three bundles.
+4. **Placement is decided in order,** for any component: repo-specific knowledge stays in that
+   repo's local configuration, where repo-specific means unusable outside that repo's codebase; an
+   artifact dispatched only by a sibling stays with its consumer; knowledge that would transfer
+   unchanged to another company using the same vendor product belongs to that vendor's integration
+   plugin; everything else is named for the artifact or practice it acts on.
+5. **A plugin description enumerates what it provides**, which makes the boundary self-enforcing at
+   review time. A component that does not fit the enumeration either forces a deliberate description
+   change or goes elsewhere.
 
 ```mermaid
 flowchart LR
-    Skill["Skill or agent"] -->|lives once in| Cap["Capability plugin<br/>named for what its skills act on"]
+    Comp["Any component"] -->|lives once in| Cap["Capability plugin<br/>named for what its components act on"]
     Cap -->|composed via dependencies into| Bundle["Role bundle<br/>name + description + dependencies, nothing else"]
     Bundle -->|installed by| Person["Person"]
+    Ext["External entry<br/>upstream files at a pinned commit"] -->|installed by| Person
 ```
 
 > _Perspective: Council reviewers ratifying the model. What separates a capability plugin from a
@@ -87,7 +89,7 @@ Rule 4's ordering is itself a decision procedure, not just a sentence:
 
 ```mermaid
 flowchart TD
-    A["New skill or agent"] --> B{"Unusable outside<br/>that repo's codebase?"}
+    A["New component"] --> B{"Unusable outside<br/>that repo's codebase?"}
     B -->|yes| B1["Stays in that repo's local configuration"]
     B -->|no| C{"Dispatched only by one sibling?"}
     C -->|yes| C1["Stays with its consumer"]
@@ -96,9 +98,14 @@ flowchart TD
     D -->|no| E["Named for the artifact or practice it acts on"]
 ```
 
-> _Perspective: A contributor placing a new skill. The four-branch test rule 4 states in prose,
+> _Perspective: A contributor placing a new component. The four-branch test rule 4 states in prose,
 > walked in order. Omits the plugin-description self-check in rule 5, which runs after this tree
 > lands on an answer._
+
+A third kind of entry sits outside both layers. An **external entry** names a third-party repository
+and a commit rather than shipping files of its own, so the pinned commit is the whole of its
+security boundary. It carries no Bitwarden practice, so no placement rule reaches it and neither
+layer contains it.
 
 Bundles use the plugin manifest's dependencies array, which the platform documents for exactly this
 purpose: a manifest consisting of only dependencies packages a curated set behind one install, and
@@ -110,26 +117,12 @@ name one is deleted. One integration plugin remains a soft dependency everywhere
 connection to an external service that prompts for credentials, and a declared edge would force that
 prompt on every member of the roles that depend on it.
 
-```mermaid
-flowchart LR
-    c1["Capability A"] --> c2["Capability B"]
-    c3["Capability C"] --> c2
-    c4["Capability D"] --> c3
-    c5["Capability E"] --> c3
-    c5 --> c6["Capability F"]
-    c4 -. soft .-> c7["Integration capability"]
-    c5 -. soft .-> c7
-```
-
-> _Perspective: Council reviewers checking that every edge names something. Every declared
-> capability-to-capability edge in the marketplace, plus the soft edges that stay undeclared.
-> Container level. Omits the capability plugins with no outgoing edges and all role bundles, which
-> attach as leaves below this graph._
-
-The operational detail lives in the marketplace repository rather than here: the exhaustive mapping
-of which skill moves where, the rename ledger, and the migration sequencing. This ADR is superseded
-only if the two-layer model itself changes. Rule 4's branch set is revisable as the marketplace
-absorbs disciplines beyond engineering, and revising it does not supersede this decision.
+The operational detail lives in the marketplace repository rather than here. Its contribution guide
+carries the procedure a contributor follows, including the placement test walked with worked
+examples, the tie-breakers that settle an ambiguous case, and the current dependency graph. This ADR
+records only the decision and what it rules out. It is superseded only if the two-layer model itself
+changes. Rule 4's branch set is revisable as the marketplace absorbs disciplines beyond engineering,
+and revising it does not supersede this decision.
 
 ### Positive consequences
 
@@ -153,7 +146,7 @@ absorbs disciplines beyond engineering, and revising it does not supersede this 
   disables every dependent sitting behind a hard-abort edge, and that radius widens as more roles
   compose the same shared plugin.
 - Marketplace entries grow in count even though ambiguity falls, because only some of the resulting
-  entries can hold a skill.
+  entries can hold a component.
 - Migration spans several pull requests, each carrying a version bump and a changelog entry, and
   some plugins need rename entries so existing installs migrate cleanly.
 - Duplication becomes harder rather than impossible. A team that wants a private copy of a skill now
@@ -177,11 +170,11 @@ flowchart LR
 
 - The contribution guide's plugin families are rewritten against this decision, and the marketplace
   catalog is regrouped by layer.
-- Plugin descriptions are rewritten to enumerate their skills.
+- Plugin descriptions are rewritten to enumerate what they provide.
 - Validation is added to CI so that every plugin-qualified reference, every skill grant, and every
   declared dependency resolves to something real, alongside the lexical invariants the marketplace
-  currently lacks. Rule 2 is one of them: a bundle directory carrying a skill, an agent, or a
-  command fails the build.
+  currently lacks. Rule 2 is one of them: a bundle directory carrying a component of any kind fails
+  the build.
 - The capability consolidations land one plugin identity per pull request, beginning with the plugin
   that has not yet shipped and can be renamed at no cost.
 - The role plugins are hollowed into bundles once their skills have moved, and a bundle is added for

--- a/docs/architecture/adr/0035-adopt-ai-plugin-taxonomy.md
+++ b/docs/architecture/adr/0035-adopt-ai-plugin-taxonomy.md
@@ -66,9 +66,9 @@ Chosen option: **two layers, capability plugins plus role bundles**. The rules a
    component serving three roles lives once and appears in three bundles.
 4. **Placement is decided in order,** for any component: repo-specific knowledge stays in that
    repo's local configuration, where repo-specific means unusable outside that repo's codebase; an
-   artifact dispatched only by a sibling stays with its consumer; knowledge that would transfer
-   unchanged to another company using the same vendor product belongs to that vendor's integration
-   plugin; everything else is named for the artifact or practice it acts on.
+   artifact dispatched only by a sibling stays with its consumer; knowledge of how Bitwarden uses a
+   vendor's product, stated generically, belongs to that vendor's integration plugin; everything
+   else is named for the artifact or practice it acts on.
 5. **A plugin description enumerates what it provides**, which makes the boundary self-enforcing at
    review time. A component that does not fit the enumeration either forces a deliberate description
    change or goes elsewhere.
@@ -92,7 +92,7 @@ flowchart TD
     B -->|yes| B1["Stays in that repo's local configuration"]
     B -->|no| C{"Dispatched only by one sibling?"}
     C -->|yes| C1["Stays with its consumer"]
-    C -->|no| D{"Transfers unchanged to another company<br/>on the same vendor product?"}
+    C -->|no| D{"How we use a vendor's product,<br/>stated generically?"}
     D -->|yes| D1["That vendor's integration plugin"]
     D -->|no| E["Named for the artifact or practice it acts on"]
 ```
@@ -100,6 +100,10 @@ flowchart TD
 > _Perspective: A contributor placing a new component. The four-branch test rule 4 states in prose,
 > walked in order. Omits the plugin-description self-check in rule 5, which runs after this tree
 > lands on an answer._
+
+The vendor branch has a reciprocal. A component driving one workflow through a vendor surface
+composes that vendor's integration plugin and hands it content, so the conventions for using the
+product stay in one place and the specialized component carries none of them.
 
 A third kind of entry sits outside both layers. An **external entry** names a third-party repository
 and a commit. Its files stay upstream, so the pinned commit is the whole of its security boundary.

--- a/docs/architecture/adr/0035-adopt-ai-plugin-taxonomy.md
+++ b/docs/architecture/adr/0035-adopt-ai-plugin-taxonomy.md
@@ -19,9 +19,9 @@ The marketplace's contribution guide defines a small number of plugin families. 
 fraction of plugins fit none of them cleanly: several have no family at all, and others fit only on
 a technicality — named for an activity rather than a role, or named for a role but shipping no agent
 and nothing but generic skills. Those are exactly the plugins whose contents are hardest to predict
-from their names. A family of domain skill libraries exists in practice but is undocumented, so it
-has no membership test, and one plugin became the default home for anything skill-shaped that was
-not a persona. It now holds several unrelated concerns behind a single name.
+from their names. A family of subject-matter skill libraries exists in practice but is undocumented,
+so it has no membership test, and one plugin became the default home for anything skill-shaped that
+was not a persona. It now holds several unrelated concerns behind a single name.
 
 The absence of a rule is measurable in the tree:
 
@@ -31,14 +31,14 @@ The absence of a rule is measurable in the tree:
   defining its boundary against the other.
 - A single process spanning many steps is split across several plugins, producing many cross-plugin
   references that exist only because the steps were separated.
-- Guidance was duplicated across two persona plugins and had to be consolidated, which is what first
-  surfaced this problem.
+- Guidance keeps getting duplicated across persona plugins, and the copies diverge before anyone
+  notices and consolidates them.
 
-A second requirement constrains any fix: the marketplace has to deliver tools according to a
-person's role, and someone in one role should not receive guidance meant for another. Many skills
-legitimately serve several roles at once. Those two goals conflict if there is only one layer of
-plugins. Grouping by role duplicates shared skills and gives them no single home; grouping only by
-domain leaves a person with no way to install the set their job needs.
+Placement is the problem to solve. Alongside it sits an opportunity: many skills serve several roles
+at once, and a person joining a role currently has to read the whole catalog to work out which
+entries apply. Grouping by role would answer that, but it duplicates shared skills and gives them no
+single home, which is the failure already on the board. A single capability layer keeps one home per
+skill and leaves the joining problem where it is.
 
 ## Considered options
 
@@ -46,22 +46,26 @@ domain leaves a person with no way to install the set their job needs.
   and placement settled case by case in review.
 - **Role plugins with deliberate duplication:** one plugin per job function, and a skill serving two
   roles is copied into both. Other organizations use this model for their own AI plugin libraries.
-- **Capability plugins only:** one home per skill, named by domain, with no role-level packaging.
-- **Two layers, capability plugins plus role bundles:** skills live once in a domain-named plugin,
-  and roles are expressed as dependency-only bundle plugins that compose them.
+- **Capability plugins only:** one home per skill, named for what its skills act on, with no
+  role-level packaging. Answers placement fully and leaves discovery to a catalog page.
+- **Two layers, capability plugins plus role bundles:** the same capability layer, plus bundle
+  plugins that hold only dependencies and compose it. The second layer is additive: it changes
+  nothing about where a skill lives.
 
 ## Decision outcome
 
 Chosen option: **two layers, capability plugins plus role bundles**. The rules at adoption:
 
 1. **A capability plugin holds skills and agents.** Every skill has exactly one home. It is named
-   for a domain, never for a job title, a seniority level, or a lifecycle phase.
+   for what its skills act on, meaning an artifact, a practice, or an integration surface, never for
+   a job title, a seniority level, or a lifecycle phase.
 2. **A role bundle holds nothing but a name, a description, and dependencies.** No skills, no
-   agents, no commands. It is what a person installs, and it is named for the role.
-3. **Placement therefore ranges only over capability plugins**, because a bundle cannot hold a
-   skill. A skill serving three roles lives once and appears in three bundles.
-4. **Placement is decided in order:** repo-specific knowledge stays in that repo's local
-   configuration; a skill dispatched only by a sibling stays with its consumer; knowledge that would
+   agents, no commands. CI enforces it. It is what a person installs, and it is named for the role.
+3. **Placement therefore ranges only over capability plugins**, because a bundle holds nothing. A
+   skill serving three roles lives once and appears in three bundles.
+4. **Placement is decided in order,** for a skill and an agent alike: repo-specific knowledge stays
+   in that repo's local configuration, where repo-specific means unusable outside that repo's
+   codebase; an artifact dispatched only by a sibling stays with its consumer; knowledge that would
    transfer unchanged to another company using the same vendor product belongs to that vendor's
    integration plugin; everything else is named for the artifact or practice it acts on.
 5. **A plugin description enumerates its skills**, which makes the boundary self-enforcing at review
@@ -70,7 +74,7 @@ Chosen option: **two layers, capability plugins plus role bundles**. The rules a
 
 ```mermaid
 flowchart LR
-    Skill["Skill or agent"] -->|lives once in| Cap["Capability plugin<br/>named for a domain"]
+    Skill["Skill or agent"] -->|lives once in| Cap["Capability plugin<br/>named for what its skills act on"]
     Cap -->|composed via dependencies into| Bundle["Role bundle<br/>name + description + dependencies, nothing else"]
     Bundle -->|installed by| Person["Person"]
 ```
@@ -83,9 +87,9 @@ Rule 4's ordering is itself a decision procedure, not just a sentence:
 
 ```mermaid
 flowchart TD
-    A["New skill"] --> B{"Repo-specific?"}
+    A["New skill or agent"] --> B{"Unusable outside<br/>that repo's codebase?"}
     B -->|yes| B1["Stays in that repo's local configuration"]
-    B -->|no| C{"Dispatched only by one sibling skill?"}
+    B -->|no| C{"Dispatched only by one sibling?"}
     C -->|yes| C1["Stays with its consumer"]
     C -->|no| D{"Transfers unchanged to another company<br/>on the same vendor product?"}
     D -->|yes| D1["That vendor's integration plugin"]
@@ -100,12 +104,11 @@ Bundles use the plugin manifest's dependencies array, which the platform documen
 purpose: a manifest consisting of only dependencies packages a curated set behind one install, and
 bundles can be pushed org-wide through managed settings.
 
-Cross-plugin dependencies are accepted at both layers, bounded by two rules. The graph stays
-shallow, ideally one level below a bundle, and every capability-to-capability edge names the
-specific skill that composes across it. An edge that cannot name one is deleted. One integration
-plugin remains a soft dependency everywhere because it ships a connection to an external service
-that prompts for credentials, and a declared edge would force that prompt on every member of the
-roles that depend on it.
+Cross-plugin dependencies are accepted at both layers, bounded by one rule: every
+capability-to-capability edge names the specific skill that composes across it. An edge that cannot
+name one is deleted. One integration plugin remains a soft dependency everywhere because it ships a
+connection to an external service that prompts for credentials, and a declared edge would force that
+prompt on every member of the roles that depend on it.
 
 ```mermaid
 flowchart LR
@@ -118,14 +121,15 @@ flowchart LR
     c5 -. soft .-> c7
 ```
 
-> _Perspective: Council reviewers assessing how deep the graph runs. Every declared
-> capability-to-capability edge in the marketplace, and how many hops deep it goes. Container level.
-> Omits the capability plugins with no outgoing edges and all role bundles, which attach as leaves
-> below this graph._
+> _Perspective: Council reviewers checking that every edge names something. Every declared
+> capability-to-capability edge in the marketplace, plus the soft edges that stay undeclared.
+> Container level. Omits the capability plugins with no outgoing edges and all role bundles, which
+> attach as leaves below this graph._
 
 The operational detail lives in the marketplace repository rather than here: the exhaustive mapping
 of which skill moves where, the rename ledger, and the migration sequencing. This ADR is superseded
-only if the two-layer model itself changes.
+only if the two-layer model itself changes. Rule 4's branch set is revisable as the marketplace
+absorbs disciplines beyond engineering, and revising it does not supersede this decision.
 
 ### Positive consequences
 
@@ -133,28 +137,9 @@ only if the two-layer model itself changes.
   plugin by construction.
 - Institutional knowledge stays single-sourced, so a reference or a process-phase gate cannot drift
   between copies.
-- A role installs one plugin and receives a scoped set. Someone in one role gets their toolkit and
-  nothing from an unrelated stack.
-
-  ```mermaid
-  flowchart TB
-      subgraph R1["Role bundle A declares 3"]
-          direction LR
-          cap1["Capability"]
-          cap2["Capability"]
-          cap3["Capability"]
-      end
-      cap2 -->|hard-abort dependency| st["Shared capability"]
-
-      subgraph R2["Role bundle B declares 1"]
-          cap4["Capability"]
-      end
-  ```
-
-  > _Perspective: Council reviewers weighing the scoped-install claim. What two representative
-  > bundles actually resolve to at install time, contrasted side by side. Component level. Omits the
-  > other bundles, which resolve by the same pattern._
-
+- A curated per-role install becomes worth having, because one home per skill makes what a bundle
+  resolves to legible rather than accidental. Bundles are being adopted independently of how
+  placement is settled, so this is a benefit the taxonomy confers rather than one it rests on.
 - Consolidating a multi-step process's skills into one plugin converts many cross-plugin references
   into intra-plugin calls, and co-locating a lookup skill with the skill that needs it makes a
   duplicated procedure removable.
@@ -164,6 +149,9 @@ only if the two-layer model itself changes.
 - The model depends on plugin dependencies, a platform feature that is documented in depth but not
   used at scale elsewhere yet. Bitwarden would be an early adopter of that machinery, and its
   failure modes each disable the dependent plugin until resolved.
+- Single-sourcing concentrates dependents onto a few shared capability plugins. A bad release of one
+  disables every dependent sitting behind a hard-abort edge, and that radius widens as more roles
+  compose the same shared plugin.
 - Marketplace entries grow in count even though ambiguity falls, because only some of the resulting
   entries can hold a skill.
 - Migration spans several pull requests, each carrying a version bump and a changelog entry, and
@@ -177,7 +165,7 @@ Follow-up work in the marketplace repository, sequenced so no step depends on a 
 
 ```mermaid
 flowchart LR
-    P0["0 · No renames<br/>delete phantoms, rewrite descriptions"] --> P1["1 · Free rename<br/>rename a plugin to match its actual domain"]
+    P0["0 · No renames<br/>delete phantoms, rewrite descriptions"] --> P1["1 · Free rename<br/>rename a plugin to match what it acts on"]
     P1 --> P2["2 · Make dependencies real<br/>README prose → declared edges"]
     P2 --> P3["3 · Consolidate<br/>related skills, related pairs"]
     P3 --> P4["4 · Hollow role plugins into bundles"]
@@ -192,7 +180,8 @@ flowchart LR
 - Plugin descriptions are rewritten to enumerate their skills.
 - Validation is added to CI so that every plugin-qualified reference, every skill grant, and every
   declared dependency resolves to something real, alongside the lexical invariants the marketplace
-  currently lacks.
+  currently lacks. Rule 2 is one of them: a bundle directory carrying a skill, an agent, or a
+  command fails the build.
 - The capability consolidations land one plugin identity per pull request, beginning with the plugin
   that has not yet shipped and can be renamed at no cost.
 - The role plugins are hollowed into bundles once their skills have moved, and a bundle is added for

--- a/docs/architecture/adr/0035-adopt-ai-plugin-taxonomy.md
+++ b/docs/architecture/adr/0035-adopt-ai-plugin-taxonomy.md
@@ -5,7 +5,7 @@ date: 2026-08-21
 tags: [clients, mobile, server, sdk]
 ---
 
-# 0035 - Adopt a taxonomy for AI skills, prompts, and agents
+# 0035 - Adopt a taxonomy for the AI plugin marketplace
 
 <AdrTable frontMatter={frontMatter}></AdrTable>
 
@@ -17,11 +17,11 @@ duplication and churn rather than as an argument anyone wins.
 
 The marketplace's contribution guide defines a small number of plugin families. A meaningful
 fraction of plugins fit none of them cleanly: several have no family at all, and others fit only on
-a technicality — named for an activity rather than a role, or named for a role but shipping no agent
-and nothing but generic skills. Those are exactly the plugins whose contents are hardest to predict
-from their names. A family of subject-matter skill libraries exists in practice but is undocumented,
-so it has no membership test, and one plugin became the default home for anything skill-shaped that
-was not a persona. It now holds several unrelated concerns behind a single name.
+a technicality, named for an activity instead of a role, or named for a role but shipping no agent
+and nothing but generic skills. Those are the plugins whose contents are hardest to predict from
+their names. A family of subject-matter skill libraries exists in practice but is undocumented, so
+it has no membership test, and one plugin became the default home for anything skill-shaped that was
+not a persona. It now holds several unrelated concerns behind a single name.
 
 The absence of a rule is measurable in the tree:
 
@@ -56,10 +56,10 @@ skill and leaves the joining problem where it is.
 
 Chosen option: **two layers, capability plugins plus role bundles**. The rules at adoption:
 
-1. **A capability plugin carries components.** Whatever kinds of component the platform supports,
-   this is what holds them, and every component has exactly one home. It is named for what its
-   components act on, meaning an artifact, a practice, or an integration surface, never for a job
-   title, a seniority level, or a lifecycle phase.
+1. **A capability plugin carries components,** whatever kinds the platform supports, and every
+   component has exactly one home. It is named for what its components act on, meaning an artifact,
+   a practice, or an integration surface, never for a job title, a seniority level, or a lifecycle
+   phase.
 2. **A role bundle holds nothing but a name, a description, and dependencies.** No components of any
    kind. CI enforces it. It is what a person installs, and it is named for the role.
 3. **Placement therefore ranges only over capability plugins**, because a bundle holds nothing. A
@@ -81,11 +81,10 @@ flowchart LR
     Ext["External entry<br/>upstream files at a pinned commit"] -->|installed by| Person
 ```
 
-> _Perspective: Council reviewers ratifying the model. What separates a capability plugin from a
-> role bundle, and how a person ends up with either. System context level. Omits concrete plugin
-> names, covered below._
+> _Perspective: Council reviewers ratifying the model. How a component reaches the person who
+> installs it. System context level. Omits the dependency edges between capability plugins._
 
-Rule 4's ordering is itself a decision procedure, not just a sentence:
+Rule 4's ordering is a decision procedure:
 
 ```mermaid
 flowchart TD
@@ -103,13 +102,12 @@ flowchart TD
 > lands on an answer._
 
 A third kind of entry sits outside both layers. An **external entry** names a third-party repository
-and a commit rather than shipping files of its own, so the pinned commit is the whole of its
-security boundary. It carries no Bitwarden practice, so no placement rule reaches it and neither
-layer contains it.
+and a commit. Its files stay upstream, so the pinned commit is the whole of its security boundary.
+It carries no Bitwarden practice, so no placement rule reaches it and neither layer contains it.
 
-Bundles use the plugin manifest's dependencies array, which the platform documents for exactly this
-purpose: a manifest consisting of only dependencies packages a curated set behind one install, and
-bundles can be pushed org-wide through managed settings.
+Bundles use the plugin manifest's dependencies array, which the platform documents for this purpose:
+a manifest consisting of only dependencies packages a curated set behind one install, and bundles
+can be pushed org-wide through managed settings.
 
 Cross-plugin dependencies are accepted at both layers, bounded by one rule: every
 capability-to-capability edge names the specific skill that composes across it. An edge that cannot
@@ -117,12 +115,11 @@ name one is deleted. One integration plugin remains a soft dependency everywhere
 connection to an external service that prompts for credentials, and a declared edge would force that
 prompt on every member of the roles that depend on it.
 
-The operational detail lives in the marketplace repository rather than here. Its contribution guide
-carries the procedure a contributor follows, including the placement test walked with worked
-examples, the tie-breakers that settle an ambiguous case, and the current dependency graph. This ADR
-records only the decision and what it rules out. It is superseded only if the two-layer model itself
-changes. Rule 4's branch set is revisable as the marketplace absorbs disciplines beyond engineering,
-and revising it does not supersede this decision.
+The operational detail lives in the marketplace repository. Its contribution guide carries the
+procedure a contributor follows, including the placement test walked with worked examples and the
+tie-breakers that settle an ambiguous case. This decision is superseded only if the two-layer model
+itself changes. Rule 4's branch set stays revisable as the marketplace absorbs disciplines beyond
+engineering.
 
 ### Positive consequences
 
@@ -159,14 +156,13 @@ Follow-up work in the marketplace repository, sequenced so no step depends on a 
 ```mermaid
 flowchart LR
     P0["0 · No renames<br/>delete phantoms, rewrite descriptions"] --> P1["1 · Free rename<br/>rename a plugin to match what it acts on"]
-    P1 --> P2["2 · Make dependencies real<br/>README prose → declared edges"]
+    P1 --> P2["2 · Make dependencies real<br/>README prose becomes declared edges"]
     P2 --> P3["3 · Consolidate<br/>related skills, related pairs"]
     P3 --> P4["4 · Hollow role plugins into bundles"]
 ```
 
-> _Perspective: Whoever sequences the migration PRs. The five phases below, in the order each
-> depends on the last. Roadmap level. Omits per-plugin task detail, which lives in the marketplace
-> repository's own tracking._
+> _Perspective: Whoever sequences the migration PRs. The order in which each phase depends on the
+> last. Omits per-plugin task detail, which lives in the marketplace repository's own tracking._
 
 - The contribution guide's plugin families are rewritten against this decision, and the marketplace
   catalog is regrouped by layer.
@@ -175,7 +171,7 @@ flowchart LR
   declared dependency resolves to something real, alongside the lexical invariants the marketplace
   currently lacks. Rule 2 is one of them: a bundle directory carrying a component of any kind fails
   the build.
-- The capability consolidations land one plugin identity per pull request, beginning with the plugin
-  that has not yet shipped and can be renamed at no cost.
+- The capability consolidations land one plugin identity per pull request, beginning with those that
+  have not shipped and can be renamed at no cost.
 - The role plugins are hollowed into bundles once their skills have moved, and a bundle is added for
-  the one role with no plugin today.
+  any role with no plugin of its own.

--- a/docs/architecture/adr/0035-adopt-ai-plugin-taxonomy.md
+++ b/docs/architecture/adr/0035-adopt-ai-plugin-taxonomy.md
@@ -82,7 +82,7 @@ flowchart LR
 ```
 
 > _Perspective: Council reviewers ratifying the model. How a component reaches the person who
-> installs it. System context level. Omits the dependency edges between capability plugins._
+> installs it. System context level. Omits the dependencies between capability plugins._
 
 Rule 4's ordering is a decision procedure:
 
@@ -113,11 +113,12 @@ Bundles use the plugin manifest's dependencies array, which the platform documen
 a manifest consisting of only dependencies packages a curated set behind one install, and bundles
 can be pushed org-wide through managed settings.
 
-Cross-plugin dependencies are accepted at both layers, bounded by one rule: every
-capability-to-capability edge names the specific skill that composes across it. An edge that cannot
-name one is deleted. One integration plugin remains a soft dependency everywhere because it ships a
-connection to an external service that prompts for credentials, and a declared edge would force that
-prompt on every member of the roles that depend on it.
+A plugin may depend on another plugin at either layer. Before declaring one, name the call: this
+skill in one plugin calls that skill in the other. A dependency nobody can name that way comes out.
+
+Dependencies are all or nothing. The platform has no optional kind, so a plugin whose dependency is
+missing does not load at all. Anything meant to work without a plugin it calls has to say so, and
+keep working when that plugin is gone.
 
 The operational detail lives in the marketplace repository. Its contribution guide carries the
 procedure a contributor follows, including the placement test walked with worked examples and the
@@ -144,8 +145,7 @@ engineering.
   used at scale elsewhere yet. Bitwarden would be an early adopter of that machinery, and its
   failure modes each disable the dependent plugin until resolved.
 - Single-sourcing concentrates dependents onto a few shared capability plugins. A bad release of one
-  disables every dependent sitting behind a hard-abort edge, and that radius widens as more roles
-  compose the same shared plugin.
+  disables every dependent, and that radius widens as more roles compose the same shared plugin.
 - Marketplace entries grow in count even though ambiguity falls, because only some of the resulting
   entries can hold a component.
 - Migration spans several pull requests, each carrying a version bump and a changelog entry, and
@@ -160,7 +160,7 @@ Follow-up work in the marketplace repository, sequenced so no step depends on a 
 ```mermaid
 flowchart LR
     P0["0 · No renames<br/>delete phantoms, rewrite descriptions"] --> P1["1 · Free rename<br/>rename a plugin to match what it acts on"]
-    P1 --> P2["2 · Make dependencies real<br/>README prose becomes declared edges"]
+    P1 --> P2["2 · Make dependencies real<br/>README prose becomes declared dependencies"]
     P2 --> P3["3 · Consolidate<br/>related skills, related pairs"]
     P3 --> P4["4 · Hollow role plugins into bundles"]
 ```


### PR DESCRIPTION
## 🎟️ Tracking

[AI-97](https://bitwarden.atlassian.net/browse/AI-97)

## 📔 Objective

Adds ADR 0035, proposing a two-layer taxonomy for AI skills, prompts, and agents: capability plugins hold skills and agents (one home per skill, named for a domain), and role bundles compose capability plugins via dependencies with no skills of their own. This resolves the ambiguity where a meaningful share of the AI plugin marketplace doesn't fit the current plugin families, which has caused skill duplication and churn.

A running implementation of this model is at [github.com/SaintPatrck/bitwarden-ai-plugins](https://github.com/SaintPatrck/bitwarden-ai-plugins/tree/refactor/plugin-taxonomy).


[AI-97]: https://bitwarden.atlassian.net/browse/AI-97?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ