### PR TITLE
docs: add ADR 0035, move SDK application crates into a product repository

### DIFF
--- a/docs/architecture/adr/0035-product-repository.md
+++ b/docs/architecture/adr/0035-product-repository.md
@@ -1,0 +1,259 @@
+---
+adr: "0035"
+status: Proposed
+date: 2026-09-09
+tags: [clients, mobile, sdk, server]
+---
+
+# 0035 - Move SDK application crates into a product repository
+
+<AdrTable frontMatter={frontMatter}></AdrTable>
+
+## Context and problem statement
+
+The `sdk-internal` repository lives on its own and reaches the clients as a published npm package
+(and a Maven package for android, a Swift package for iOS). Every breaking change in the SDK has to
+travel through that publish step before any consumer can adopt the change that follows it. That
+turns delivery into a single serialized pipeline: many teams write to the SDK, everything funnels
+through one published version, and many teams consume it on the other side. One team's unfinished
+downstream fix holds up everyone waiting for a later SDK change.
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 560" fontFamily="ui-sans-serif, system-ui, sans-serif">
+  <text x="120" y="70" fill="#1a1a1a" fontSize="30">SDK</text>
+  <text x="472" y="66" fill="#888" fontSize="26">NPM</text>
+  <text x="800" y="70" fill="#1a1a1a" fontSize="30">Clients</text>
+
+  <line x1="500" y1="110" x2="500" y2="490" fill="none" stroke="#888" strokeWidth="2" />
+
+  <g fill="none" stroke="#1a1a1a" strokeWidth="3" strokeLinecap="round">
+    <path d="M70,120 L290,120 C360,120 380,300 450,300" />
+    <path d="M70,165 L240,165 C330,165 370,300 450,300" />
+    <path d="M70,210 L190,210 C300,210 350,300 450,300" />
+    <path d="M70,480 L290,480 C360,480 380,300 450,300" />
+    <path d="M70,435 L240,435 C330,435 370,300 450,300" />
+    <path d="M70,390 L190,390 C300,390 350,300 450,300" />
+    <path d="M70,300 L450,300" />
+    <path d="M550,300 C650,300 700,210 810,210 L930,210" />
+    <path d="M550,300 C630,300 660,165 760,165 L930,165" />
+    <path d="M550,300 C620,300 640,120 710,120 L930,120" />
+    <path d="M550,300 C650,300 700,390 810,390 L930,390" />
+    <path d="M550,300 C630,300 660,435 760,435 L930,435" />
+    <path d="M550,300 C620,300 640,480 710,480 L930,480" />
+    <path d="M550,300 L930,300" />
+  </g>
+
+  <path d="M450,300 L550,300" fill="none" stroke="#1a1a1a" strokeWidth="3" strokeLinecap="round" strokeDasharray="2 14" />
+</svg>
+
+Put another way: every breaking change in the SDK adds to a queue of fixes that then have to merge
+on the clients side in the same order they merged in the SDK. If Team A merges a breaking change
+into the SDK, every other team waits for Team A's corresponding client fix before it can pull in any
+SDK change that landed after the break.
+
+We have tried to manage this without changing the structure. The breaking-change detection workflow
+builds the latest `clients` `main` against SDK PRs so a breaking change can arrive with its fix PR
+ready. It has not held the line: breaking changes have gone up, not down, even with the workflow in
+place. Doing nothing is not a stable position, because the pressure grows as more features and more
+teams move into the SDK.
+
+A 12-month measurement (2025-09-01 to 2026-08-31, read from merged PRs and git history) shows the
+shape of the problem:
+
+- **68 forced downstream breaking events**: clients 18, android 28, iOS 22. The earlier six months
+  had 25; the recent six months had 43, about 1.7x, with August the peak at 16.
+- **About 20% of merges to `sdk-internal` main are breaking**: 149 of 754. Distinct authors per
+  month grew from about 14 to about 29 over the year. More contributors means more breaking changes.
+- **Concurrency is the norm.** Every one of the 149 breaking merges had another breaking merge
+  within 14 days; 143 of 149 within 3 days. A consumer picking up a new version does not adopt one
+  break, it adopts a bundle of unrelated breaks at once.
+- **Nothing gates the publish.** npm and Maven publish on every merge to main. The breaking-change
+  check runs on PRs, comments, and adds a `breaking-change` label, but never fails the job (a
+  known-breaking PR, #906, passed green). So a breaking change ships to consumers whether or not its
+  downstream fix exists.
+- **Code review is not the bottleneck.** On clients, review latency is negligible and total blocked
+  time is small (median 2.4 hours). Mobile is a different shape: android and iOS adopt on a rolling
+  branch, with median branch windows of about 80 and 165 hours, but that window is dominated by
+  adaptation effort and the branch sitting open between re-bumps, not by waiting for a reviewer, and
+  per-break approval time cannot be cleanly separated from it. The cost across all three repos is
+  coordination and adaptation, not code review.
+  - Keep in mind that this is absolute time and the real cost is person-hours across the blocked
+    teams. On repositories like `clients` that can easily mean an order of magnitude more
+    person-hours.
+- **The churn is in the application layer.** Breaks across the dataset are dominated by SDK-owned
+  surface changes (struct and field reshapes, renames, unions, new APIs), and the clients coupling
+  points are mostly vault, tools, admin-console, and importer code.
+
+The reason to act is not the size of the problem today, it is the trend. The main driver is upstream
+in the SDK, and it grows with the number of contributing teams, so the problem gets worse as
+adoption grows.
+
+The server relationship is a separate matter. Server changes reach the SDK through generated API
+bindings, but server-owned enum-variant breaks are rare in the data (clients 0, android 1, iOS 1).
+And because the app and the server ship independently, they always have to stay compatible with each
+other over the wire, which no source layout changes. That is separate work, not part of this
+decision.
+
+## Considered options
+
+- **Do nothing, improve iteratively:** keep the repos separate and reduce breaks at the edges (SDK
+  owns construction so added fields do not break callers, new fields optional by default, fewer
+  fine-grained types for clients to construct or match, a client-side facade).
+- **Ban breaking changes (additive-only):** never change the exported surface in place; add
+  alongside, deprecate, reap.
+- **Coordinated merge gate:** keep the repos separate, make the existing breaking-change check
+  enforcing, and merge a breaking SDK change together with its client and mobile fixes as one gated
+  set (a distributed atomic merge across repos).
+- **Monorepo:** move the whole SDK into the `clients` repository, the way `jslib` was folded in
+  before.
+- **Product repository:** split the SDK crates. Move the application-logic crates into the product
+  repository so they compile together with the clients that consume them, and keep the core
+  infrastructure crates as a separately published, versioned library that every product depends on.
+
+### Do nothing, improve iteratively
+
+Reducing breaks at the interface is worth doing regardless, and it composes with any other choice.
+On its own it does not remove the bottleneck, and it does not stop breaking changes from happening.
+It is a set of smaller wins, not an answer to the serialized pipeline.
+
+### Ban breaking changes (additive-only)
+
+If nothing ever breaks, the bottleneck disappears. The cost is the overhead of carrying and later
+cleaning up backwards-compatible surface, and with Rust that overhead can grow sharply with each
+change. Some of the residue (nullability relaxations, semantic restructures) does not go additive
+cleanly and still has to be coordinated as a real break.
+
+### Coordinated merge gate
+
+This is the strongest alternative that keeps the repos separate. It reaches the same "a break cannot
+merge without its fixes" guarantee as the monorepo, and it covers mobile without moving any
+repository. The breaking-change detection it would rely on already exists (advisory today), so
+making the check enforcing is a small change, but the cross-repo merge coordination is new work we
+would have to build. It also does not remove the bottleneck. A cross-repo atomic merge still has to
+wait for the SDK to build on main, publish to the package registry, the clients PR to update its SDK
+version, and CI to re-run on that change. And it leaves the open question of what happens to other
+merges in the window between an SDK merge and its downstream fix: block them, and for how long. The
+coordination logic (ordering, timing, separate CIs) is fiddly to build and maintain.
+
+### Monorepo
+
+Folding the whole SDK into `clients` gives the atomic-commit guarantee: a change to the SDK lands in
+the same commit as the consumer updates it requires, and main is never broken because a change that
+broke a consumer would break CI. It removes the concurrent-bundle problem by construction. The
+drawback is that it binds the shared core into one product's repository. Bitwarden is moving toward
+being a multi-product company, and a single repository that owns both the password-manager
+application code and the crypto and infrastructure core makes it harder, not easier, for a second
+product to depend on that core. It solves this problem while working against the direction the
+product is heading.
+
+### Product repository
+
+Split the crate graph along the layering that already exists. The application-logic crates (for
+example `bitwarden-vault`, `bitwarden-send`, `bitwarden-generators`, `bitwarden-exporters`) move
+into the product repository and compile together with the clients that consume them, so their churn
+no longer crosses a repository boundary. The core infrastructure crates (for example
+`bitwarden-core`, `bitwarden-crypto`, `bitwarden-encoding`, `bitwarden-state`) stay a separately
+published, versioned library that every product depends on. It keeps the monorepo's guarantee for
+the layer that actually churns, and keeps the core shareable across products. The cost is the same
+as the monorepo (a large one-time migration and a bigger repository) plus the work of drawing the
+crate boundary.
+
+## Decision outcome
+
+Chosen option: **Product repository**, because it removes the bottleneck for the layer that causes
+it while keeping the shared core available to future products.
+
+The repository this creates is best understood not as "clients plus the SDK" but as **the Password
+Manager product**: the client apps together with the application-logic crates they consume. Once
+they build from the same source, there is no published package version between them to keep in sync.
+A change to the application code and the client code that uses it becomes one change that only
+merges if it builds, the same way changing a class and its callers in one commit is one change. For
+the application surface, where most of the measured breaking events come from, the cross-repo
+breaking change stops being a separate thing to coordinate, and the concurrent-bundle problem goes
+away by construction.
+
+Against the coordinated merge gate, the difference is that this removes the serialized pipeline
+rather than automating around it. The merge gate reaches for the same "cannot merge unfixed"
+guarantee, but it keeps the publish-and-bump round trip and leaves the unanswered "what do we do in
+the window" question. Compiling together answers both by construction.
+
+Against the plain monorepo, the difference is the core. Keeping the infrastructure crates as a
+shared, versioned library lets Secrets Manager and future products depend on the same core, and it
+sets up extracting products out of the `clients` repository later. The monorepo would fold the core
+into one product and make that harder.
+
+This rests on one assumption: **products do not need to share application logic at the SDK level,
+only the core.** If that turns out false for some piece of application logic, there are two ways
+out: promote that piece down into the shared core and accept that it evolves across the published
+boundary like the rest of core, or model the relationship as product and sub-product, where a
+sub-product depends on a product. Neither looks likely, and both keep the design intact if the
+assumption breaks, so it is a manageable bet.
+
+A public SDK does not change this. To be useful it has to expose product operations like vault and
+send access, which is application logic, so like the client apps it is a consumer of the product,
+not part of the shared core. Its feasibility is unaffected by this decision.
+
+The upfront migration is real work, but it is one-time work, and we have done a version of it before
+when `jslib` moved into `clients`. What it buys is an environment where we can write changes as
+often as we want to the application layer without carrying a compatibility burden or waiting on a
+cross-repo pipeline, weighed against a coordination cost that otherwise grows with every new team
+contributing to the SDK.
+
+### Positive consequences
+
+- Most of the measured breaking events stop being cross-repo events at all. A change to the
+  application surface and the client code that uses it is one commit that only merges if it builds,
+  so main stays green by construction and there is no published version to bundle.
+- The core stays a shared, versioned library, so Secrets Manager and future products can depend on
+  it, and the change sets up extracting products out of the `clients` repository later.
+- Tooling and people get the full product context in one place. AI review, for example, sees the SDK
+  change and the client code that calls it in the same diff, instead of an opaque package-version
+  bump with a new API.
+- One-time migration cost, with a precedent (`jslib`), against a coordination cost that otherwise
+  grows with the number of contributing teams.
+
+### Negative consequences
+
+- A large upfront migration, plus the work of drawing the crate boundary between core and
+  application.
+- A bigger repository: git operations and CI get slower unless CI is scoped to build only the
+  projects affected by a change.
+- It does not remove the adaptation work. Changing a shared type still means updating every place
+  that uses it; co-locating turns that into one commit instead of a cross-repo sequence, but the
+  adaptation itself is no smaller.
+- Core-layer breaks still cross a published-package boundary between the core library and the
+  product repository. This is smaller than today because the core churns less than the application
+  layer, but it is real. The plan addresses it with explicit versioning of the core.
+- It does not touch compatibility between deployed apps and the server. They ship independently, so
+  they always have to stay compatible with each other, and that is separate work regardless of how
+  the source is organized.
+
+### Plan
+
+- Draw the crate boundary in `sdk-internal`: classify each crate as core infrastructure (shared) or
+  application logic (product-specific). The obvious cases are legible from the crate names; the
+  in-between crates (`bitwarden-auth`, `bitwarden-sync`, and the crypto-management crates like
+  `bitwarden-user-crypto-management`) need a deliberate call.
+- Publish the core crates as their own versioned library, on **explicit versions** rather than
+  auto-publishing on every merge, so products adopt a core change on their own schedule.
+- Set up required infrastructure to build the SDK in `clients`. Try to scope CI so a change builds
+  and tests only the components it affects, to keep the larger repository workable.
+- Move the application-logic crates into the product repository so they compile together with the
+  clients.
+- Treat extracting a second product (for example Secrets Manager) out of the `clients` repository as
+  a later step this structure enables, not part of this migration.
+
+## Open questions
+
+- **Mobile.** Do we bring android and iOS into the product repository as part of this decision, or
+  leave them as standalone repositories for now and move only the SDK application crates and clients
+  first? The mobile repos carry the larger share of the measured breaking events, but they also add
+  Swift and Kotlin build graphs and Xcode/Gradle CI to the repository, which is the heaviest part of
+  the migration.
+
+## Follow-ups
+
+- **The server circular dependency.** `sdk-internal` and `server` currently have a circular
+  relationship. Moving the application crates into the product repository would make `server` depend
+  on `clients`, which is the wrong direction. A true product repository, where the server and client
+  components live in the same repository and both depend on a shared Rust core there, would resolve
+  this. Whether that is compatible with the backend MSA direction has not been explored.


### PR DESCRIPTION
## 🎟️ Tracking

No Jira ticket. This ADR came out of a cross-repo breaking-changes investigation.

## 📔 Objective

Adds ADR 0035 (status: Proposed): move the SDK's application-logic crates into a product repository so they compile together with the clients that consume them, while keeping the core infrastructure crates as a separately published, versioned library shared across products.

The ADR records the problem (breaking changes serialized through the npm/Maven publish pipeline, worsening as more teams contribute to the SDK), the options considered (do nothing, additive-only, coordinated merge gate, plain monorepo, product repository), and the decision with its consequences, plan, open questions (mobile), and follow-ups (the server circular dependency).

Proposed for discussion.

<details>
  <summary>If you prefer you can also look at the hand-written version/starting point</summary>

# Input for ADR

Ever since we introduced more teams into the SDK we've had a continuous challenge: Breaking changes.
Developers want to move fast, and the best way of doing that is using breaking changes, because of this
we've continuously tried to find ways of enabling this. An example of this is the breaking changes detection
workflow which coordinates with the `clients` monorepo to build the latest `main` `clients` commit against
SDK PRs (this actually started with a purely static analysis of the TypeScript types on the SDK repo alone).
The goal of this workflow was to encourage and guide developers to have fix PRs for the breaking changes reviewed and ready for merge. Unfortunately, it hasn't achieved this to the degree that we were hoping for as we've seen breaking changes increase even with the workflow. I argue that not doing anything is not an option, as the situation will continue to deteriorate as more and more features and development moves to the SDK. 

## What is the problem with breaking changes?

The issues with breaking changes can be traced back to the SDK living in a separate repository and pulled into the clients as a published NPM package because of how it collapses the flow into a serialized delivery pipeline. In other words, it creates a bottleneck.

<!-- Hourglass pinch illustration -->
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 560" font-family="ui-sans-serif, system-ui, sans-serif">
  <style>
    .rail  { fill: none; stroke: #1a1a1a; stroke-width: 3; stroke-linecap: round; }
    .dash  { fill: none; stroke: #1a1a1a; stroke-width: 3; stroke-linecap: round; stroke-dasharray: 2 14; }
    .npm   { fill: none; stroke: #888;    stroke-width: 2; }
    .label { fill: #1a1a1a; font-size: 30px; }
    .npmlabel { fill: #888; font-size: 26px; }
  </style>

  <!-- labels -->
  <text class="label" x="120" y="70">SDK</text>
  <text class="npmlabel" x="465" y="66">NPM</text>
  <text class="label" x="800" y="70">Clients</text>

  <!-- NPM boundary -->
  <line class="npm" x1="500" y1="110" x2="500" y2="490"/>

  <!-- SDK rails converging onto the baseline (above) -->
  <path class="rail" d="M70,120 L290,120 C360,120 380,300 450,300"/>
  <path class="rail" d="M70,165 L240,165 C330,165 370,300 450,300"/>
  <path class="rail" d="M70,210 L190,210 C300,210 350,300 450,300"/>
  <!-- SDK rails converging onto the baseline (below, mirrored) -->
  <path class="rail" d="M70,480 L290,480 C360,480 380,300 450,300"/>
  <path class="rail" d="M70,435 L240,435 C330,435 370,300 450,300"/>
  <path class="rail" d="M70,390 L190,390 C300,390 350,300 450,300"/>
  <!-- SDK baseline -->
  <path class="rail" d="M70,300 L450,300"/>

  <!-- single line across the NPM boundary -->
  <path class="dash" d="M450,300 L550,300"/>

  <!-- Clients rails fanning back out (above) -->
  <path class="rail" d="M550,300 C650,300 700,210 810,210 L930,210"/>
  <path class="rail" d="M550,300 C630,300 660,165 760,165 L930,165"/>
  <path class="rail" d="M550,300 C620,300 640,120 710,120 L930,120"/>
  <!-- Clients rails fanning back out (below, mirrored) -->
  <path class="rail" d="M550,300 C650,300 700,390 810,390 L930,390"/>
  <path class="rail" d="M550,300 C630,300 660,435 760,435 L930,435"/>
  <path class="rail" d="M550,300 C620,300 640,480 710,480 L930,480"/>
  <!-- Clients baseline -->
  <path class="rail" d="M550,300 L930,300"/>
</svg>

Think of this in another way, every breaking change in the SDK adds to a queue of fixes that then need to be merged on the clients repo, in the same order as they were merged in the SDK. So if Team A merges a breaking change into the SDK, then every other team needs to wait for the corresponding clients fix until they can start pulling in SDK features merged _after_ the breaking change.

I did some research by asking Claude to look at the previous 12 months. When reading it it's important to note that, while research may show a median breaking change on clients only taking a couple of hours to fix, that is a couple of hours where *nobody else* can merge. It's one thing to look at it from the perspective of absolute time, and another from the perspective of total person-hours affected. Here is what the research found: [claude: insert your research and conclusions here].

## Side-note on Server - SDK breaking changes

These also present a challenge because of how we automatically generate API bindings from server commits.
However, this relationship is a bit different and can be split into two parts: 

### Compile time breaks
These are the ones that are most similar to the SDK - Clients breaks. If a breaking change is merged on the server then
a fix needs to be merged on the SDK before any additional changes after the break can be pulled in. The research shows [claude: insert research here (these are not as common)].

## Run time breaks
These come from the fact that running SDK instances are not physically tied to a server version (SDK is client side, Server is server), meaning that the SDK needs to combine static type safety with the ability to handle unknown data coming from an unknown server version. This is fundamentally different from SDK - Client where the SDK is physically bundled with each client at compile time. We need to follow-up on this separately, but it is just a matter of implementing better support for these scenarios, and not an architectural re-design.

## Alternatives considered

### Coordinated merge gate (cross-repo/meta-repo)

Keep the repos separate, but link a breaking sdk-internal change to its clients/mobile `fixes` and merge them together as one gated change set, essentially a distributed atomic merge. This would probably be implemented as an extension of the automations we already have.

#### Advantages
- Same guarantee as the monorepo (a breaking change can't merge without its fixes).
- Builds on automation we already have.

#### Disadvantages
- Cross-repo merge coordination is complex to build and maintain (ordering, timing, separate CIs).
- There's a limit to how fast a merge can happen because you have to wait for:
  - SDK to be built on main
  - SDK to be deployed to package repository
  - Clients to update PR with correct SDK `package.json` version
  - Clients PR to re-build CI after change
- Does not remove the bottleneck: What happens in the time after an SDK PR is merged and before the Clients fix is merged? Do we block additional PR merges? For how long?

### Ban breaking changes

Exactly what it says, ban breaking changes and force every update to be backwards compatible.

#### Advantages

- Effectively resolves all issues.

#### Disadvantages

- Adds a bunch of overhead needed to maintain backwards compatibility (and then cleaning it up).
- "a bunch of overhead" really doesn't do it justice, the time spent on this can increase exponentially with every change because of how strict rust is.

### Do nothing - improve what we can

Continue allowing breaking changes, don't move any repositories, don't add any gates.
This actually turns into a collection of smaller solutions, some examples:

- Reduce breaks by changing our interface, examples:
  - Let the SDK own construction (builders/constructors) so added fields don't break callers
  - Make new fields optional by default,
  - Minimise the fine-grained types clients have to construct or exhaustively match
- Insulate clients behind a facade layer

#### Advantages

- Iterative improvements, no big work effort.
- Not disruptive

#### Disadvantages

- Doesn't address the bottleneck
- Will still cause breaking changes

### Monorepo

The solution that was chosen for `jslib`: move the SDK into the `clients` repo.

#### Advantages

- Breaking changes can no longer be merged without fixing them because that would break CI.
- Existing AI tools automatically get the entire context, e.g. when reviewing.

#### Disadvantages

- A lot of upfront work to migrate
- Bigger repository, slower git, CI, etc.

### Product repository

Similar to the monorepo but taking Bitwarden's ambition of becoming a true multi-product company into account. The core idea here is: Move closely related code together to address the most frequent breaking changes but keep the core infrastructure separate and available for other products. There is a fundamental assumption being made here: Products will not need to share application logic at the SDK level. 

#### Advantages

- Same as for monorepo.
- Prepares us for extracting products from the `clients` repo, e.g. Secrets Manager.

#### Disadvantages

- Also same as for monorepo.

## Solution chosen: Product repository

This solution combines a few key traits that makes it stand out as the best solution: Fastest development time, smallest maintenance cost. It's a one time effort, one that we've done before with `jslib`, which results in an environment that lets us write any type of changes as often as we want without having to worry about compatibility.

Some additional points [claude: try to merge these into flowing text with the section above]:

- What about a public SDK? The feasibility of that is not affected by this change. We would simply treat it as another client/artifact that we release.

## Open question

- Do we decide what to do with `mobile` now? Or leave it as a standalone repo for now?

## Follow ups

- The SDK and Server repositories currently have a circular relationship. Moving to a product repo would cause Server to depend on Clients instead. This could be solved by moving towards a true product repository in which case the Server and Client components would naturally depend on their common SDK/Rust core. If this is compatible with MSA on the backend has not been explored.
</details>